### PR TITLE
UI updated

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { ApolloProvider } from '@apollo/client';
-import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+import { CssBaseline, ThemeProvider, createTheme, Grow, Fade } from '@mui/material';
 import Register from './components/Register';
 import Home from './components/Home';
 import Landing from './components/Landing';
@@ -18,6 +18,8 @@ import client from './apollo-client';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { postLoginPath } from './utils/roles';
 import { ZPC_COLORS, ZPC_FONTS, ZPC_GLASS, ZPC_RADIUS } from './theme/zpcTheme';
+import { ZPC_TRANSITION } from './theme/motion';
+import PageEnter from './components/motion/PageEnter';
 
 const theme = createTheme({
   palette: {
@@ -58,10 +60,50 @@ const theme = createTheme({
   components: {
     MuiCssBaseline: {
       styleOverrides: {
+        html: {
+          backgroundColor: '#B2DFDB',
+        },
         body: {
-          backgroundColor: ZPC_COLORS.bg,
+          backgroundColor: '#B2DFDB',
           color: ZPC_COLORS.text,
         },
+      },
+    },
+    MuiDialog: {
+      defaultProps: {
+        TransitionComponent: Grow,
+        transitionDuration: ZPC_TRANSITION.popup,
+      },
+      styleOverrides: {
+        paper: {
+          // Smooth feel even if a Dialog overrides TransitionComponent
+          transitionTimingFunction: 'cubic-bezier(0.22, 1, 0.36, 1)',
+        },
+      },
+    },
+    MuiDrawer: {
+      defaultProps: {
+        transitionDuration: ZPC_TRANSITION.drawer,
+      },
+    },
+    MuiPopover: {
+      defaultProps: {
+        TransitionComponent: Fade,
+        transitionDuration: ZPC_TRANSITION.popover,
+      },
+    },
+    MuiMenu: {
+      defaultProps: {
+        TransitionComponent: Fade,
+        transitionDuration: ZPC_TRANSITION.popover,
+      },
+    },
+    MuiTooltip: {
+      defaultProps: {
+        enterDelay: 280,
+        leaveDelay: 60,
+        TransitionComponent: Fade,
+        TransitionProps: { timeout: 140 },
       },
     },
     MuiPaper: {
@@ -93,18 +135,35 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           backgroundImage:
-            'linear-gradient(180deg, rgba(22,48,42,0.48) 0%, rgba(22,48,42,0.28) 100%)',
-          backgroundColor: 'rgba(22, 48, 42, 0.38)',
-          backdropFilter: 'blur(18px) saturate(1.25)',
-          WebkitBackdropFilter: 'blur(18px) saturate(1.25)',
+            'linear-gradient(180deg, rgba(22,48,42,0.42) 0%, rgba(22,48,42,0.22) 55%, rgba(22,48,42,0.28) 100%), linear-gradient(180deg, rgba(235,230,212,0.14) 0%, rgba(235,230,212,0) 42%)',
+          backgroundColor: 'rgba(22, 48, 42, 0.32)',
+          backdropFilter: 'blur(20px) saturate(1.35)',
+          WebkitBackdropFilter: 'blur(20px) saturate(1.35)',
           borderBottom: '1px solid rgba(235,230,212,0.28)',
-          boxShadow: '0 8px 28px rgba(10, 18, 16, 0.12), inset 0 1px 0 rgba(235,230,212,0.18)',
+          boxShadow:
+            '0 8px 28px rgba(10, 18, 16, 0.14), inset 0 1px 0 rgba(235,230,212,0.28), inset 0 -1px 0 rgba(10,18,16,0.12)',
           color: ZPC_COLORS.primaryContrast,
           '& .MuiIconButton-root:hover': {
-            backgroundColor: 'rgba(15, 34, 28, 0.55)',
+            backgroundColor: 'rgba(235, 230, 212, 0.12)',
           },
           '& .MuiButton-root:hover': {
-            backgroundColor: 'rgba(15, 34, 28, 0.55)',
+            backgroundColor: 'rgba(235, 230, 212, 0.12)',
+          },
+        },
+      },
+    },
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          minHeight: 32,
+          borderRadius: 999,
+          textTransform: 'none',
+          fontWeight: 600,
+          color: ZPC_COLORS.textMuted,
+          transition: 'background-color 0.2s cubic-bezier(0.22, 1, 0.36, 1), color 0.2s ease',
+          '&.Mui-selected': {
+            color: ZPC_COLORS.primaryContrast,
+            backgroundColor: ZPC_GLASS.tabActive,
           },
         },
       },
@@ -123,20 +182,8 @@ const theme = createTheme({
         indicator: {
           display: 'none',
         },
-      },
-    },
-    MuiTab: {
-      styleOverrides: {
-        root: {
-          minHeight: 32,
-          borderRadius: 999,
-          textTransform: 'none',
-          fontWeight: 600,
-          color: ZPC_COLORS.textMuted,
-          '&.Mui-selected': {
-            color: ZPC_COLORS.primaryContrast,
-            backgroundColor: ZPC_GLASS.tabActive,
-          },
+        flexContainer: {
+          transition: 'none',
         },
       },
     },
@@ -342,8 +389,10 @@ const RoleProtectedRoute: React.FC<RoleProtectedRouteProps> = ({ children, allow
 };
 
 function AppRoutes() {
+  const location = useLocation();
   return (
-    <Routes>
+    <PageEnter enterKey={location.pathname}>
+      <Routes location={location}>
       {/* Public Routes */}
       <Route
         path="/"
@@ -398,7 +447,7 @@ function AppRoutes() {
       <Route
         path="/create-property"
         element={
-          <RoleProtectedRoute allowedRoles={['builder', 'admin']}>
+          <RoleProtectedRoute allowedRoles={['agent', 'builder']}>
             <CreateProperty />
           </RoleProtectedRoute>
         }
@@ -406,7 +455,7 @@ function AppRoutes() {
       <Route
         path="/my-properties"
         element={
-          <RoleProtectedRoute allowedRoles={['builder', 'admin']}>
+          <RoleProtectedRoute allowedRoles={['agent', 'builder']}>
             <MyProperties />
           </RoleProtectedRoute>
         }
@@ -449,7 +498,8 @@ function AppRoutes() {
 
       {/* Catch all route */}
       <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+      </Routes>
+    </PageEnter>
   );
 }
 

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -2,8 +2,8 @@ import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   Box, Typography, TextField, IconButton, Avatar, InputAdornment,
   Divider, List, ListItemButton, ListItemAvatar, ListItemText,
-  Badge, Tooltip, Dialog, DialogTitle, DialogContent, DialogActions,
-  Button, ToggleButton, ToggleButtonGroup, Chip, CircularProgress,
+  Badge, Tooltip, Dialog, DialogTitle, DialogContent,
+  Button, CircularProgress,
   useMediaQuery,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
@@ -11,7 +11,6 @@ import EditIcon from '@mui/icons-material/Edit';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import VideoCallOutlinedIcon from '@mui/icons-material/VideoCallOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import GroupAddOutlinedIcon from '@mui/icons-material/GroupAddOutlined';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import CloseIcon from '@mui/icons-material/Close';
 import MinimizeIcon from '@mui/icons-material/Minimize';
@@ -20,7 +19,7 @@ import { useNavigate, useLocation, Navigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { useApolloClient, useQuery } from '@apollo/client';
 import { SEARCH_USERS_LIGHT, GET_USER_PROFILE } from '../graphql/user';
-import { CREATE_DM_ROOM_MUTATION, CREATE_GROUP_ROOM_MUTATION, GET_USER_ROOMS, GET_PRESENCE } from '../graphql/chat';
+import { CREATE_DM_ROOM_MUTATION, GET_USER_ROOMS, GET_PRESENCE } from '../graphql/chat';
 import Chat from './Chat';
 import { MATTE_SURFACE, PAGE_ATMOSPHERE } from '../theme/surfaces';
 import { isRecentlyActive } from '../utils/datetime';
@@ -100,12 +99,17 @@ const displayNameFromParticipants = (
     otherId: other.userId ? String(other.userId) : undefined,
   };
 };
-const fmtTime = (ms?: number) => {
-  if (!ms) return '';
-  const d = new Date(ms);
+const fmtTime = (ms?: number | string | null) => {
+  if (ms == null || ms === '') return '';
+  const n = typeof ms === 'string' ? Number(ms) : ms;
+  // Hide empty / epoch / Go zero-time (year 0001) / garbage timestamps
+  if (!Number.isFinite(n) || n < 946684800000) return ''; // before 2000-01-01
+  const d = new Date(n);
+  if (Number.isNaN(d.getTime())) return '';
   const now = new Date();
-  if (d.toDateString() === now.toDateString())
+  if (d.toDateString() === now.toDateString()) {
     return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
   return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
 };
 
@@ -143,13 +147,9 @@ const ConvItem: React.FC<{
           overlap="circular"
           anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
           badgeContent={
-            conv.type === 'group'
-              ? <Box sx={{ width: 14, height: 14, bgcolor: '#EBE6D4', borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                  <GroupAddOutlinedIcon sx={{ fontSize: 10, color: LI_BLUE }} />
-                </Box>
-              : online
-                ? <Box sx={{ width: 12, height: 12, bgcolor: '#16302A', borderRadius: '50%', border: '2px solid #EBE6D4' }} />
-                : null
+            online
+              ? <Box sx={{ width: 12, height: 12, bgcolor: '#16302A', borderRadius: '50%', border: '2px solid #EBE6D4' }} />
+              : null
           }
         >
           <Avatar
@@ -210,11 +210,8 @@ const NewConvDialog: React.FC<{
   myUserId: string;
 }> = ({ open, onClose, onStart, myUserId }) => {
   const apollo = useApolloClient();
-  const [type, setType]             = useState<ConvType>('direct');
   const [userSearch, setUserSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [groupName, setGroupName]   = useState('');
-  const [members, setMembers]       = useState<Array<{ id: string; label: string }>>([]);
   const [error, setError]           = useState<string | null>(null);
 
   useEffect(() => {
@@ -256,7 +253,7 @@ const NewConvDialog: React.FC<{
       return scored.length > 0 ? scored.map((s) => s.u) : raw;
     }, [data?.users, debouncedSearch]);
 
-  const reset = () => { setType('direct'); setUserSearch(''); setGroupName(''); setMembers([]); setError(null); };
+  const reset = () => { setUserSearch(''); setError(null); };
   const handleClose = () => { reset(); onClose(); };
 
   const startDirect = async (u: { id: string; firstName: string; lastName: string }) => {
@@ -289,36 +286,6 @@ const NewConvDialog: React.FC<{
     }
   };
 
-  const toggleMember = (u: { id: string; firstName: string; lastName: string }) => {
-    const id = u.id;
-    const label = `${u.firstName} ${u.lastName}`.trim();
-    setMembers(prev => prev.some(m => m.id === id) ? prev.filter(m => m.id !== id) : [...prev, { id, label }]);
-  };
-
-  const startGroup = async () => {
-    const name = groupName.trim();
-    if (!name || members.length === 0) return;
-    const memberIds = [myUserId, ...members.map(m => m.id)];
-    setError(null);
-    try {
-      const result = await apollo.mutate({
-        mutation: CREATE_GROUP_ROOM_MUTATION,
-        variables: { createdBy: myUserId, name, memberIds },
-        fetchPolicy: 'network-only',
-      });
-      const roomId = result.data?.createGroupRoom?.roomId;
-      if (!roomId) {
-        setError('Failed to create group. Please try again.');
-        return;
-      }
-      onStart({ id: roomId, type: 'group', label: name, participants: memberIds, unread: 0 });
-      handleClose();
-    } catch (err) {
-      console.error('Failed to create group room', err);
-      setError('Failed to create group. Please try again.');
-    }
-  };
-
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: 3, ...MATTE_SURFACE } }}>
       <DialogTitle sx={{ pb: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -332,36 +299,14 @@ const NewConvDialog: React.FC<{
             {error}
           </Typography>
         )}
-        <ToggleButtonGroup value={type} exclusive onChange={(_, v) => v && setType(v)} size="small" fullWidth sx={{ mb: 2 }}>
-          <ToggleButton value="direct" sx={{ textTransform: 'none', fontWeight: 600, gap: 0.5 }}>
-            <PersonOutlineIcon fontSize="small" /> Direct message
-          </ToggleButton>
-          <ToggleButton value="group" sx={{ textTransform: 'none', fontWeight: 600, gap: 0.5 }}>
-            <GroupAddOutlinedIcon fontSize="small" /> Group chat
-          </ToggleButton>
-        </ToggleButtonGroup>
-
-        {type === 'group' && (
-          <TextField fullWidth size="small" label="Group name" placeholder="e.g. ZPC Team"
-            value={groupName} onChange={e => setGroupName(e.target.value)} sx={{ mb: 1.5 }} />
-        )}
 
         <TextField autoFocus fullWidth size="small"
-          placeholder={type === 'direct' ? 'Search people (2+ letters)…' : 'Search members to add…'}
+          placeholder="Search people (2+ letters)…"
           value={userSearch} onChange={e => setUserSearch(e.target.value)}
           helperText={userSearch.trim().length === 1 ? 'Type at least 2 letters to search names' : ' '}
           FormHelperTextProps={{ sx: { mx: 0, minHeight: 18 } }}
           InputProps={{ startAdornment: <InputAdornment position="start"><SearchIcon sx={{ fontSize: 16, color: '#A89F84' }} /></InputAdornment> }}
         />
-
-        {type === 'group' && members.length > 0 && (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
-            {members.map(m => (
-              <Chip key={m.id} label={m.label} size="small"
-                onDelete={() => setMembers(prev => prev.filter(x => x.id !== m.id))} sx={{ fontSize: 12 }} />
-            ))}
-          </Box>
-        )}
 
         <Box sx={{ mt: 1.5, maxHeight: 260, overflowY: 'auto', borderRadius: 2, border: '1px solid #DDD6C0' }}>
           {loading ? (
@@ -370,13 +315,10 @@ const NewConvDialog: React.FC<{
             <Typography variant="caption" color="#A89F84" sx={{ display: 'block', textAlign: 'center', py: 3 }}>No users found</Typography>
           ) : (
             <List disablePadding>
-              {apiUsers.filter(u => String(u.id) !== myUserId).map(u => {
-                const isMember = members.some(m => m.id === String(u.id));
-                return (
+              {apiUsers.filter(u => String(u.id) !== myUserId).map(u => (
                   <ListItemButton key={u.id}
-                    onClick={() => type === 'direct' ? startDirect(u) : toggleMember(u)}
-                    selected={isMember}
-                    sx={{ py: 1, px: 1.5, '&.Mui-selected': { bgcolor: '#E8E2CE' } }}
+                    onClick={() => startDirect(u)}
+                    sx={{ py: 1, px: 1.5 }}
                   >
                     <ListItemAvatar sx={{ minWidth: 44 }}>
                       <Avatar src={u.profilePhotoSignedUrl} sx={{ width: 34, height: 34, bgcolor: stringToColor(`${u.firstName} ${u.lastName}`), fontSize: 13 }}>
@@ -387,30 +329,12 @@ const NewConvDialog: React.FC<{
                       primary={<Typography variant="body2" fontWeight={600} fontSize={13}>{u.firstName} {u.lastName}</Typography>}
                       secondary={<Typography variant="caption" color="#A89F84" fontSize={11}>{u.role ?? u.email}</Typography>}
                     />
-                    {type === 'group' && isMember && (
-                      <Box sx={{ width: 18, height: 18, bgcolor: LI_BLUE, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                        <CloseIcon sx={{ fontSize: 11, color: '#EBE6D4' }} />
-                      </Box>
-                    )}
                   </ListItemButton>
-                );
-              })}
+              ))}
             </List>
           )}
         </Box>
       </DialogContent>
-
-      {type === 'group' && (
-        <DialogActions sx={{ px: 3, pb: 2 }}>
-          <Button onClick={handleClose} sx={{ textTransform: 'none', color: '#3A4540' }}>Cancel</Button>
-          <Button variant="contained" onClick={startGroup}
-            disabled={!groupName.trim() || members.length === 0}
-            sx={{ textTransform: 'none', fontWeight: 700, bgcolor: LI_BLUE, borderRadius: 5, px: 3, '&:hover': { bgcolor: '#16302A' } }}
-          >
-            Create group ({members.length})
-          </Button>
-        </DialogActions>
-      )}
     </Dialog>
   );
 };
@@ -441,7 +365,6 @@ const ChatPage: React.FC<ChatPageProps> = ({
   const [activeId, setActiveId]           = useState<string | null>(null);
   const [search, setSearch]               = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [filter, setFilter]               = useState<'all' | 'groups'>('all');
   const [newDlgOpen, setNewDlgOpen]       = useState(false);
   const [mobileView, setMobileView]       = useState<'sidebar' | 'chat'>('sidebar');
   const [wsConnected, setWsConnected]     = useState(false);
@@ -450,6 +373,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
   const [peerRecentlyActive, setPeerRecentlyActive] = useState<Record<string, boolean>>({});
   const [dockMinimized, setDockMinimized] = useState(false);
   const [startingDmId, setStartingDmId]   = useState<string | null>(null);
+  const [dmError, setDmError]             = useState<string | null>(null);
   // Map of userId → "First Last" for resolving DM conversation labels
   const [userNames, setUserNames]         = useState<Record<string, string>>(() => {
     const cache = readPeerCache();
@@ -478,7 +402,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
     pollInterval: 20000,
   });
 
-  const peopleSearchActive = debouncedSearch.length >= 2 && filter === 'all' && !shouldRedirectToHomeDock;
+  const peopleSearchActive = debouncedSearch.length >= 2 && !shouldRedirectToHomeDock;
   const { data: peopleData, loading: peopleLoading } = useQuery(SEARCH_USERS_LIGHT, {
     variables: { search: debouncedSearch, page: 1, limit: 30 },
     skip: !peopleSearchActive || !userId,
@@ -560,7 +484,8 @@ const ChatPage: React.FC<ChatPageProps> = ({
         participants: memberIds,
         peerId: isGroup ? undefined : otherId,
         lastMessage: r.lastMessage || undefined,
-        lastTime: r.lastMessageAt || undefined,
+        // No preview text ⇒ no real messages yet — don't show a fake "Jan 1" date
+        lastTime: r.lastMessage ? (Number(r.lastMessageAt) || undefined) : undefined,
         unread: r.hasUnread ? 1 : 0,
       };
     });
@@ -711,16 +636,18 @@ const ChatPage: React.FC<ChatPageProps> = ({
 
   const startDmWithUser = useCallback(async (u: { id: string; firstName: string; lastName: string }) => {
     if (!userId) return;
-    const otherId = u.id;
+    const otherId = String(u.id);
     const existing = conversations.find(c =>
       c.type === 'direct' && c.participants.includes(otherId) && c.participants.includes(userId)
     );
     if (existing) {
       openConversation(existing);
       setSearch('');
+      setDockMinimized(false);
       return;
     }
     setStartingDmId(otherId);
+    setDmError(null);
     try {
       const result = await apollo.mutate({
         mutation: CREATE_DM_ROOM_MUTATION,
@@ -728,14 +655,19 @@ const ChatPage: React.FC<ChatPageProps> = ({
         fetchPolicy: 'network-only',
       });
       const roomId = result.data?.createDmRoom?.roomId;
-      if (!roomId) return;
+      if (!roomId) {
+        setDmError('Could not start chat. Please try again.');
+        console.error('Failed to start DM from search: empty roomId', result);
+        return;
+      }
       const label = `${u.firstName} ${u.lastName}`.trim();
       setUserNames(prev => ({ ...prev, [otherId]: label }));
       const cache = readPeerCache();
       cache[otherId] = { name: label, avatarUrl: cache[otherId]?.avatarUrl };
       writePeerCache(cache);
+      setDockMinimized(false);
       handleNewConv({
-        id: roomId,
+        id: String(roomId),
         type: 'direct',
         label,
         labelReady: true,
@@ -744,12 +676,17 @@ const ChatPage: React.FC<ChatPageProps> = ({
         avatarUrl: userAvatars[otherId] || cache[otherId]?.avatarUrl,
         unread: 0,
       });
-    } catch (err) {
+      setSearch('');
+    } catch (err: any) {
       console.error('Failed to start DM from search', err);
+      const msg = String(err?.message || err || '');
+      setDmError(msg.includes('chat_rooms') || msg.includes('does not exist')
+        ? 'Messaging database is not ready. Please retry in a moment.'
+        : 'Could not start chat. Please try again.');
     } finally {
       setStartingDmId(null);
     }
-  }, [userId, conversations, apollo, handleNewConv, openConversation]);
+  }, [userId, conversations, apollo, handleNewConv, openConversation, userAvatars]);
 
   const handlePeerPresenceChange = useCallback((peerUserId: string, isOnline: boolean) => {
     setPeerOnline(prev => {
@@ -782,14 +719,15 @@ const ChatPage: React.FC<ChatPageProps> = ({
   const activePeerLive = !!(activePeerId && peerOnline[activePeerId]);
 
   const q = search.trim().toLowerCase();
+  // Groups disabled for now — only show direct conversations
   const filtered = conversations.filter(c => {
-    const matchFilter = filter === 'all' || c.type === 'group';
-    if (!q) return matchFilter;
+    if (c.type === 'group') return false;
+    if (!q) return true;
     const matchLabel = c.label.toLowerCase().includes(q);
     const matchMsg = (c.lastMessage || '').toLowerCase().includes(q);
     const peerName = c.peerId ? String(userNames[c.peerId] || '').toLowerCase() : '';
     const matchPeer = !!peerName && peerName.includes(q);
-    return matchFilter && (matchLabel || matchMsg || matchPeer);
+    return matchLabel || matchMsg || matchPeer;
   });
 
   // Show people matches; skip those already visible in the chats list above.
@@ -961,25 +899,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
               },
             }}
           />
-          {search.trim().length === 1 && filter === 'all' && (
+          {search.trim().length === 1 && (
             <Typography sx={{ mt: 0.75, fontSize: 11.5, color: '#A89F84' }}>
               Type at least 2 letters to find people
             </Typography>
           )}
-
-          <Box sx={{ display: 'flex', gap: 0.5, mt: 1.25 }}>
-            {(['all', 'groups'] as const).map(f => (
-              <Box key={f} onClick={() => setFilter(f)} sx={{
-                px: 1.5, py: 0.4, borderRadius: 5, cursor: 'pointer', fontSize: 12.5, fontWeight: 600, userSelect: 'none',
-                bgcolor: filter === f ? '#E8E2CE' : 'transparent',
-                color: filter === f ? LI_BLUE : '#3A4540',
-                border: `1px solid ${filter === f ? LI_BLUE : 'transparent'}`,
-                '&:hover': { bgcolor: filter === f ? '#E8E2CE' : LI_BG },
-              }}>
-                {f === 'all' ? 'Focused' : 'Groups'}
-              </Box>
-            ))}
-          </Box>
         </Box>
 
         {/* List */}
@@ -994,7 +918,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
                 <>
                   {isSearching && (
                     <Typography sx={{ px: 2, pt: 1.5, pb: 0.5, fontSize: 11, fontWeight: 700, color: '#A89F84', textTransform: 'uppercase', letterSpacing: 0.4 }}>
-                      {filter === 'groups' ? 'Groups' : 'Chats & messages'}
+                      Chats & messages
                     </Typography>
                   )}
                   <List disablePadding>
@@ -1016,6 +940,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
                   <Typography sx={{ px: 2, pt: 1.5, pb: 0.5, fontSize: 11, fontWeight: 700, color: '#A89F84', textTransform: 'uppercase', letterSpacing: 0.4 }}>
                     People
                   </Typography>
+                  {dmError && (
+                    <Typography sx={{ px: 2, pb: 1, fontSize: 12, color: '#B91C1C' }}>
+                      {dmError}
+                    </Typography>
+                  )}
                   {peopleLoading ? (
                     <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
                       <CircularProgress size={22} sx={{ color: LI_BLUE }} />
@@ -1076,7 +1005,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
                   <Typography variant="caption" color="#3A4540" lineHeight={1.5}>
                     {isSearching
                       ? 'Try another name, or type at least 2 letters to find people.'
-                      : 'Search for people above, or use compose to start a group.'}
+                      : 'Search for people above, or use compose to start a chat.'}
                   </Typography>
                 </Box>
               )}

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -15,6 +15,7 @@ import GroupAddOutlinedIcon from '@mui/icons-material/GroupAddOutlined';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import CloseIcon from '@mui/icons-material/Close';
 import MinimizeIcon from '@mui/icons-material/Minimize';
+import LogoutIcon from '@mui/icons-material/Logout';
 import { useNavigate, useLocation, Navigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { useApolloClient, useQuery } from '@apollo/client';
@@ -421,12 +422,17 @@ const ChatPage: React.FC<ChatPageProps> = ({
   onClose,
   initialRoomId = null,
 }) => {
-  const { user }  = useAuth();
+  const { user, clearAuth } = useAuth();
   const navigate  = useNavigate();
   const location  = useLocation();
   const isWide = useMediaQuery('(min-width:901px)');
   // Dock on desktop when embedded on Home, or when somehow rendered wide in-page
   const isDesktopDock = embedded || isWide;
+
+  const handleLogout = useCallback(() => {
+    clearAuth();
+    window.location.href = '/';
+  }, [clearAuth]);
 
   const userId      = user ? String(user.id) : '';
   const shouldRedirectToHomeDock = !embedded && isWide;
@@ -913,8 +919,20 @@ const ChatPage: React.FC<ChatPageProps> = ({
                   <EditIcon sx={{ fontSize: 18 }} />
                 </IconButton>
               </Tooltip>
+              {!isDesktopDock && (
+                <Tooltip title="Logout">
+                  <IconButton size="small" onClick={handleLogout} sx={{ color: '#3A4540', '&:hover': { bgcolor: LI_BG, color: LI_BLUE } }}>
+                    <LogoutIcon sx={{ fontSize: 18 }} />
+                  </IconButton>
+                </Tooltip>
+              )}
               {isDesktopDock && (
                 <>
+                  <Tooltip title="Logout">
+                    <IconButton size="small" onClick={handleLogout} sx={{ color: '#3A4540', '&:hover': { bgcolor: LI_BG, color: LI_BLUE } }}>
+                      <LogoutIcon sx={{ fontSize: 18 }} />
+                    </IconButton>
+                  </Tooltip>
                   <Tooltip title="Minimize">
                     <IconButton size="small" onClick={() => setDockMinimized(true)} sx={{ color: '#3A4540' }}>
                       <MinimizeIcon sx={{ fontSize: 18 }} />

--- a/src/components/CreatePost.tsx
+++ b/src/components/CreatePost.tsx
@@ -23,6 +23,7 @@ import {
   ListSubheader,
   CircularProgress,
   Alert,
+  Grow,
 } from '@mui/material';
 // Removed Grid import to avoid dependency on Unstable_Grid2; using CSS grid instead
 import {
@@ -37,7 +38,9 @@ import {
   VideoFile as VideoIcon
 } from '@mui/icons-material';
 import LocationAutocomplete from './LocationAutocomplete';
-import { MATTE_SURFACE, MATTE_INSET } from '../theme/surfaces';
+import { MATTE_SURFACE, MATTE_INSET, THIN_CREAM_SCROLLBAR } from '../theme/surfaces';
+import { expandPrettyMentions, getTextareaCaretOffset } from '../utils/mentions';
+import { ZPC_MOTION } from '../theme/motion';
 
 const interFont = {
   fontFamily: "'Source Serif 4', 'Source Serif Pro', Georgia, serif",
@@ -64,23 +67,21 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
   const [mentionOpen, setMentionOpen] = useState(false);
   const [mentionSearch, setMentionSearch] = useState('');
   const [mentionStart, setMentionStart] = useState<number | null>(null);
+  const [mentionAnchor, setMentionAnchor] = useState({ top: 0, left: 0 });
   const mentionedUserIdsRef = useRef<Set<string>>(new Set());
+  const mentionedUserNamesRef = useRef<Map<string, string>>(new Map());
+  const mentionedPropertyNamesRef = useRef<Map<string, string>>(new Map());
   const descriptionRef = useRef<HTMLTextAreaElement | HTMLInputElement | null>(null);
+  const descriptionWrapRef = useRef<HTMLDivElement | null>(null);
   const mentionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const [searchUsers, { data: mentionData, loading: mentionLoading }] = useLazyQuery(
+  const [searchUsers, { data: mentionData, loading: mentionLoading, error: mentionError }] = useLazyQuery(
     SEARCH_USERS_LIGHT,
-    {
-      fetchPolicy: 'network-only',
-      nextFetchPolicy: 'cache-first',
-    }
+    { fetchPolicy: 'network-only', nextFetchPolicy: 'cache-first', errorPolicy: 'all' }
   );
-  const [searchPropertiesQuery, { data: propertyMentionData, loading: propertyMentionLoading }] = useLazyQuery(
+  const [searchPropertiesQuery, { data: propertyMentionData, loading: propertyMentionLoading, error: propertyMentionError }] = useLazyQuery(
     PUBLIC_PROPERTIES,
-    {
-      fetchPolicy: 'network-only',
-      nextFetchPolicy: 'cache-first',
-    }
+    { fetchPolicy: 'network-only', nextFetchPolicy: 'cache-first', errorPolicy: 'all' }
   );
 
   const postTypes = [
@@ -151,6 +152,20 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
     setLongitude(locationData.longitude);
   };
 
+  const updateMentionAnchor = (el: HTMLTextAreaElement | HTMLInputElement, cursorPos: number) => {
+    const coords = getTextareaCaretOffset(el, cursorPos);
+    const fieldRect = el.getBoundingClientRect();
+    const wrapRect = descriptionWrapRef.current?.getBoundingClientRect();
+    const offsetTop = wrapRect ? fieldRect.top - wrapRect.top : el.offsetTop;
+    const offsetLeft = wrapRect ? fieldRect.left - wrapRect.left : el.offsetLeft;
+    const panelWidth = 280;
+    const maxLeft = Math.max(8, (wrapRect?.width || fieldRect.width) - panelWidth - 8);
+    setMentionAnchor({
+      top: offsetTop + coords.top + coords.height + 4,
+      left: Math.min(Math.max(8, offsetLeft + coords.left), maxLeft),
+    });
+  };
+
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const value = e.target.value;
     setDescription(value);
@@ -169,14 +184,15 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
       setMentionOpen(true);
       setMentionSearch(searchTerm);
       setMentionStart(cursorPos - atMatch[0].length);
-      // Debounce so we don't hit Neon on every keystroke / block behind other loads
+      updateMentionAnchor(e.target, cursorPos);
       mentionTimerRef.current = setTimeout(() => {
-        searchUsers({
-          variables: { search: searchTerm.trim(), page: 1, limit: 8 },
-        });
-        searchPropertiesQuery({
-          variables: { city: searchTerm.trim() || undefined, page: 1, limit: 8 },
-        });
+        const term = searchTerm.trim();
+        if (term.length < 2) return;
+        searchUsers({ variables: { search: term, page: 1, limit: 8 } });
+        const cityToken = term.split(/\s+/)[0];
+        if (cityToken.length >= 2) {
+          searchPropertiesQuery({ variables: { city: cityToken, page: 1, limit: 8 } });
+        }
       }, 280);
     } else {
       setMentionOpen(false);
@@ -187,30 +203,29 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
 
   const handleSelectMention = (user: { id: string; firstName: string; lastName?: string }) => {
     if (mentionStart === null) return;
-
-    const displayName = user.firstName;
-    const token = `@[${user.id}:${displayName}]`;
+    const displayName = `${user.firstName || ''} ${user.lastName || ''}`.trim() || 'User';
+    const token = `@${displayName}`;
     const before = description.slice(0, mentionStart);
     const after = description.slice(mentionStart + 1 + mentionSearch.length);
     const nextDescription = `${before}${token} ${after}`.slice(0, 500);
-
     setDescription(nextDescription);
     mentionedUserIdsRef.current.add(user.id);
+    mentionedUserNamesRef.current.set(displayName, user.id);
     setMentionOpen(false);
     setMentionSearch('');
     setMentionStart(null);
-
     setTimeout(() => descriptionRef.current?.focus(), 0);
   };
 
   const handleSelectPropertyMention = (prop: { id: string; title: string }) => {
     if (mentionStart === null) return;
     const label = (prop.title || 'Property').replace(/[\[\]]/g, '').slice(0, 40);
-    const token = `@[p:${prop.id}:${label}]`;
+    const token = `@${label}`;
     const before = description.slice(0, mentionStart);
     const after = description.slice(mentionStart + 1 + mentionSearch.length);
     const nextDescription = `${before}${token} ${after}`.slice(0, 500);
     setDescription(nextDescription);
+    mentionedPropertyNamesRef.current.set(label, prop.id);
     setMentionOpen(false);
     setMentionSearch('');
     setMentionStart(null);
@@ -219,13 +234,16 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
 
   const handleSubmit = () => {
     if (!selectedType || !title.trim() || !description.trim() || loading) return;
-    // Drop focus so the button doesn't stay visually highlighted
     (document.activeElement as HTMLElement | null)?.blur?.();
-
+    const content = expandPrettyMentions(
+      description.trim(),
+      mentionedUserNamesRef.current,
+      mentionedPropertyNamesRef.current,
+    );
     const postData = {
       type: selectedType,
       title: title.trim(),
-      content: description.trim(),
+      content,
       location: location.trim(),
       latitude,
       longitude,
@@ -233,7 +251,6 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
       media: uploadedFiles,
       mentionedUserIds: Array.from(mentionedUserIdsRef.current),
     };
-
     onSubmit(postData);
   };
 
@@ -247,6 +264,8 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
     setVisibility('public');
     setUploadedFiles([]);
     mentionedUserIdsRef.current = new Set();
+    mentionedUserNamesRef.current = new Map();
+    mentionedPropertyNamesRef.current = new Map();
     setMentionOpen(false);
     setMentionSearch('');
     setMentionStart(null);
@@ -272,6 +291,7 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
     <Modal
       open={open}
       onClose={handleClose}
+      closeAfterTransition
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -279,13 +299,18 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
         p: 2
       }}
     >
+      <Grow in={open} timeout={{ enter: ZPC_MOTION.popupEnter, exit: ZPC_MOTION.popupExit }}>
       <Box
+        tabIndex={-1}
         sx={{
           ...MATTE_SURFACE,
           borderRadius: 3,
           width: { xs: '100%', sm: '90%', md: '900px', lg: '900px' },
           maxHeight: '90vh',
-          overflow: 'auto',
+          overflow: 'hidden',
+          outline: 'none',
+          display: 'flex',
+          flexDirection: 'column',
           ...interFont
         }}
       >
@@ -295,9 +320,11 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
           alignItems: 'center', 
           justifyContent: 'space-between', 
           p: 3, 
+          flexShrink: 0,
           ...MATTE_SURFACE,
           boxShadow: 'none',
-          borderRadius: '12px 12px 0 0',
+          borderRadius: 0,
+          borderBottom: '1px solid rgba(22,48,42,0.08)',
         }}>
           <Box>
             <Typography 
@@ -337,7 +364,7 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
         </Box>
 
         {/* Content */}
-        <Box sx={{ p: 3 }}>
+        <Box sx={{ p: 3, flex: 1, minHeight: 0, overflow: 'auto', ...THIN_CREAM_SCROLLBAR }}>
           {/* Post Type Selection */}
           <Box sx={{ mb: 3 }}>
             <Typography 
@@ -451,7 +478,7 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
             </Typography>
           </Box>
 
-          <Box sx={{ mb: 3, position: 'relative' }}>
+          <Box sx={{ mb: 3, position: 'relative' }} ref={descriptionWrapRef}>
             <Typography 
               sx={{ 
                 fontWeight: 600, 
@@ -491,49 +518,66 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
             />
             {mentionOpen && (
               <Paper
-                elevation={4}
+                elevation={6}
                 sx={{
                   position: 'absolute',
-                  left: 0,
-                  right: 0,
-                  top: '100%',
-                  mt: 0.5,
-                  zIndex: 10,
+                  top: mentionAnchor.top,
+                  left: mentionAnchor.left,
+                  width: 280,
+                  maxWidth: 'calc(100% - 16px)',
+                  zIndex: 20,
                   maxHeight: 220,
                   overflow: 'auto',
+                  borderRadius: 2,
+                  border: '1px solid rgba(22,48,42,0.14)',
+                  animation: `zpcPopupIn ${ZPC_MOTION.popover}ms ${ZPC_MOTION.ease} both`,
+                  ...THIN_CREAM_SCROLLBAR,
                 }}
               >
                 <List dense disablePadding>
-                  {(mentionLoading || propertyMentionLoading) && (
-                    <ListItemButton disabled>
-                      <ListItemText primary="Searching…" />
-                    </ListItemButton>
-                  )}
                   <ListSubheader sx={{ lineHeight: '28px', ...MATTE_INSET }}>People</ListSubheader>
-                  {!mentionLoading && (mentionData?.users?.length ?? 0) === 0 && (
-                    <ListItemButton disabled>
-                      <ListItemText primary="No users found" />
-                    </ListItemButton>
+                  {mentionSearch.trim().length < 2 && (
+                    <ListItemButton disabled><ListItemText primary="Type 2+ letters to search" /></ListItemButton>
+                  )}
+                  {mentionSearch.trim().length >= 2 && mentionLoading && (
+                    <ListItemButton disabled><ListItemText primary="Searching people…" /></ListItemButton>
+                  )}
+                  {mentionSearch.trim().length >= 2 && !mentionLoading && mentionError && (
+                    <ListItemButton disabled><ListItemText primary="Couldn’t load people" /></ListItemButton>
+                  )}
+                  {mentionSearch.trim().length >= 2 && !mentionLoading && !mentionError && (mentionData?.users?.length ?? 0) === 0 && (
+                    <ListItemButton disabled><ListItemText primary="No users found" /></ListItemButton>
                   )}
                   {(mentionData?.users ?? []).map((user: any) => (
                     <ListItemButton key={`u-${user.id}`} onClick={() => handleSelectMention(user)}>
                       <ListItemText
                         primary={`${user.firstName} ${user.lastName || ''}`.trim()}
                         secondary={user.role || user.email}
+                        primaryTypographyProps={{ noWrap: true, fontSize: 13.5, fontWeight: 600 }}
+                        secondaryTypographyProps={{ noWrap: true, fontSize: 11.5 }}
                       />
                     </ListItemButton>
                   ))}
                   <ListSubheader sx={{ lineHeight: '28px', ...MATTE_INSET }}>Properties</ListSubheader>
-                  {!propertyMentionLoading && (propertyMentionData?.publicProperties?.properties?.length ?? 0) === 0 && (
-                    <ListItemButton disabled>
-                      <ListItemText primary="No properties found" />
-                    </ListItemButton>
+                  {mentionSearch.trim().length < 2 && (
+                    <ListItemButton disabled><ListItemText primary="Type 2+ letters to search" /></ListItemButton>
+                  )}
+                  {mentionSearch.trim().length >= 2 && propertyMentionLoading && (
+                    <ListItemButton disabled><ListItemText primary="Searching properties…" /></ListItemButton>
+                  )}
+                  {mentionSearch.trim().length >= 2 && !propertyMentionLoading && propertyMentionError && (
+                    <ListItemButton disabled><ListItemText primary="Couldn’t load properties" /></ListItemButton>
+                  )}
+                  {mentionSearch.trim().length >= 2 && !propertyMentionLoading && !propertyMentionError && (propertyMentionData?.publicProperties?.properties?.length ?? 0) === 0 && (
+                    <ListItemButton disabled><ListItemText primary="No properties found" /></ListItemButton>
                   )}
                   {(propertyMentionData?.publicProperties?.properties ?? []).slice(0, 8).map((prop: any) => (
                     <ListItemButton key={`p-${prop.id}`} onClick={() => handleSelectPropertyMention(prop)}>
                       <ListItemText
                         primary={prop.title}
                         secondary={prop.location || prop.city || 'Property'}
+                        primaryTypographyProps={{ noWrap: true, fontSize: 13.5, fontWeight: 600 }}
+                        secondaryTypographyProps={{ noWrap: true, fontSize: 11.5 }}
                       />
                     </ListItemButton>
                   ))}
@@ -700,9 +744,20 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
               {error}
             </Alert>
           )}
+        </Box>
 
           {/* Action Buttons */}
-          <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 2,
+              justifyContent: 'flex-end',
+              flexShrink: 0,
+              px: 3,
+              py: 2,
+              borderTop: '1px solid rgba(22,48,42,0.08)',
+            }}
+          >
             <Button
               variant="outlined"
               onClick={handleClose}
@@ -762,8 +817,8 @@ const CreatePost: React.FC<CreatePostProps> = ({ open, onClose, onSubmit, loadin
               {loading ? 'Creating post…' : 'Create Post'}
             </Button>
           </Box>
-        </Box>
       </Box>
+      </Grow>
     </Modal>
   );
 };

--- a/src/components/CreateProperty.tsx
+++ b/src/components/CreateProperty.tsx
@@ -1,40 +1,53 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
-  Box,
-  Typography,
-  TextField,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  IconButton,
-  AppBar,
-  Toolbar,
-  Snackbar,
   Alert,
-  CircularProgress
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Fade,
+  IconButton,
+  Snackbar,
+  Stack,
+  TextField,
+  Typography,
 } from '@mui/material';
-import {
-  ArrowBack as ArrowBackIcon,
-  Home as HomeIcon,
-  AttachMoney as PriceIcon,
-  Description as DescriptionIcon
-} from '@mui/icons-material';
+import CloseIcon from '@mui/icons-material/Close';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import HourglassTopIcon from '@mui/icons-material/HourglassTop';
+import BadgeIcon from '@mui/icons-material/Badge';
+import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
+import SendIcon from '@mui/icons-material/Send';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { useNavigate } from 'react-router-dom';
 import { useApolloClient } from '@apollo/client';
 import { PropertyService, mapFormDataToPropertyInput } from '../services/propertyService';
-import { PropertyType, ListingType } from '../types/property';
+import { PropertyType, ListingType, Property } from '../types/property';
 import LocationAutocomplete from './LocationAutocomplete';
-import { MATTE_SURFACE, MATTE_HEADER, PAGE_ATMOSPHERE } from '../theme/surfaces';
+import { MATTE_SURFACE, THIN_CREAM_SCROLLBAR } from '../theme/surfaces';
+import { ZPC_COLORS, ZPC_FONTS } from '../theme/zpcTheme';
+import { ZPC_MOTION } from '../theme/motion';
+
+const fieldSx = {
+  '& .MuiOutlinedInput-root': {
+    bgcolor: '#fff',
+    borderRadius: 2,
+  },
+};
 
 const CreateProperty: React.FC = () => {
   const navigate = useNavigate();
   const client = useApolloClient();
   const propertyService = useMemo(() => new PropertyService(client), [client]);
+  const docInputRef = useRef<HTMLInputElement | null>(null);
+  const photoInputRef = useRef<HTMLInputElement | null>(null);
 
   const [formData, setFormData] = useState({
     title: '',
@@ -48,41 +61,75 @@ const CreateProperty: React.FC = () => {
     city: '',
     state: '',
     country: 'India',
+    builderName: '',
+    projectName: '',
+    reraId: '',
   });
-
+  const [documents, setDocuments] = useState<File[]>([]);
+  const [photos, setPhotos] = useState<File[]>([]);
   const [loading, setLoading] = useState(false);
-  const [snackbar, setSnackbar] = useState<{
-    open: boolean;
-    message: string;
-    severity: 'success' | 'error';
-  }>({ open: false, message: '', severity: 'success' });
+  const [created, setCreated] = useState<Property | null>(null);
+  const [showReviewModal, setShowReviewModal] = useState(false);
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
 
   const handleInputChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
   };
 
   const handleLocationSelect = (locationData: { address: string; latitude: number; longitude: number }) => {
-    const truncatedLocation = locationData.address.split(',').slice(0, 3).join(',').trim();
+    const parts = locationData.address.split(',').map((p) => p.trim()).filter(Boolean);
     setFormData((prev) => ({
       ...prev,
-      location: truncatedLocation,
-      city: truncatedLocation.split(',')[0]?.trim() || prev.city,
+      location: parts.slice(0, 3).join(', '),
+      city: parts[0] || prev.city,
+      state: parts[1] || prev.state,
     }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!formData.title.trim() || !formData.description.trim() || !formData.location.trim()) {
-      setSnackbar({ open: true, message: 'Please fill in title, description, and location', severity: 'error' });
+    if (!formData.title.trim() || !formData.location.trim()) {
+      setSnackbar({ open: true, message: 'Please fill in property name and location', severity: 'error' });
       return;
     }
 
     setLoading(true);
     try {
-      const created = await propertyService.createProperty(mapFormDataToPropertyInput(formData));
-      await propertyService.updatePropertyStatus(created.id, 'PUBLISHED');
-      setSnackbar({ open: true, message: 'Property created and published!', severity: 'success' });
-      setTimeout(() => navigate('/my-properties'), 1500);
+      const descBits = [
+        formData.description.trim(),
+        documents.length ? `Documents attached: ${documents.map((d) => d.name).join(', ')}` : '',
+        photos.length ? `Photos selected: ${photos.length}` : '',
+      ].filter(Boolean);
+
+      const createdProp = await propertyService.createProperty(
+        mapFormDataToPropertyInput({
+          ...formData,
+          description: descBits.join('\n\n') || formData.title,
+        })
+      );
+
+      // Persist document filenames as features for now (media upload pipeline TBD)
+      if (documents.length) {
+        try {
+          await propertyService.addPropertyFeatures(
+            createdProp.id,
+            documents.map((doc, i) => ({
+              featureName: 'DOCUMENT',
+              featureValue: `${doc.name} (${Math.max(1, Math.round(doc.size / 1024))} KB)`,
+              displayOrder: i + 1,
+            }))
+          );
+        } catch {
+          /* non-blocking */
+        }
+      }
+
+      setCreated(createdProp);
+      setShowReviewModal(true);
     } catch (error: any) {
       setSnackbar({ open: true, message: error.message || 'Failed to create property', severity: 'error' });
     } finally {
@@ -90,107 +137,402 @@ const CreateProperty: React.FC = () => {
     }
   };
 
-  return (
-    <Box sx={{ minHeight: '100vh', ...PAGE_ATMOSPHERE }}>
-      <AppBar position="static" elevation={0} sx={{ ...MATTE_HEADER }}>
-        <Toolbar>
-          <IconButton onClick={() => navigate('/home')} sx={{ mr: 2, color: '#374151' }}>
-            <ArrowBackIcon />
-          </IconButton>
-          <Typography variant="h6" sx={{ color: '#111827', fontWeight: 600 }}>
-            Create New Property
-          </Typography>
-        </Toolbar>
-      </AppBar>
+  const closeReviewModal = (goToProperty?: boolean) => {
+    setShowReviewModal(false);
+    if (goToProperty && created?.id) navigate(`/property/${created.id}`);
+    else navigate('/my-properties');
+  };
 
-      <Container maxWidth="md" sx={{ py: 4 }}>
-        <Card sx={{ borderRadius: 3, ...MATTE_SURFACE }}>
-          <CardContent sx={{ p: 4 }}>
-            <Box component="form" onSubmit={handleSubmit} sx={{ display: 'grid', gap: 3 }}>
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        bgcolor: 'rgba(10,18,16,0.45)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        p: { xs: 1.5, sm: 3 },
+      }}
+    >
+      <Fade in timeout={ZPC_MOTION.popupEnter}>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          sx={{
+            width: '100%',
+            maxWidth: 720,
+            maxHeight: '92vh',
+            overflow: 'hidden',
+            bgcolor: '#fff',
+            borderRadius: 3,
+            boxShadow: '0 24px 64px rgba(10,18,16,0.28)',
+            display: 'flex',
+            flexDirection: 'column',
+            animation: `zpcPopupIn ${ZPC_MOTION.popupEnter}ms ${ZPC_MOTION.ease} both`,
+          }}
+        >
+          <Box sx={{ px: 3, pt: 3, pb: 1.5, position: 'relative', flexShrink: 0 }}>
+            <Typography sx={{ fontFamily: ZPC_FONTS.display, fontWeight: 700, fontSize: 22, color: '#0A1210' }}>
+              Add New Property
+            </Typography>
+            <Typography sx={{ color: '#6B7280', fontSize: 13.5, mt: 0.5 }}>
+              Provide details to list your property on ZPC
+            </Typography>
+            <IconButton
+              onClick={() => navigate(-1)}
+              sx={{ position: 'absolute', top: 16, right: 12, color: '#9CA3AF' }}
+              aria-label="Close"
+            >
+              <CloseIcon />
+            </IconButton>
+          </Box>
+
+          <Box sx={{ px: 3, pb: 2, display: 'grid', gap: 2.25, flex: 1, minHeight: 0, overflow: 'auto', ...THIN_CREAM_SCROLLBAR }}>
+            <Box>
+              <Typography sx={{ fontWeight: 600, fontSize: 13.5, mb: 0.75, color: '#1F2937' }}>Property Name</Typography>
               <TextField
                 fullWidth
-                label="Property Title"
+                placeholder="Enter a clear, descriptive title (e.g., Oasis Heights Luxury Apartments)"
                 value={formData.title}
                 onChange={(e) => handleInputChange('title', e.target.value)}
                 required
-                InputProps={{ startAdornment: <HomeIcon sx={{ mr: 1, color: '#6B7280' }} /> }}
+                sx={fieldSx}
               />
+            </Box>
 
-              <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 3 }}>
-                <FormControl fullWidth required>
-                  <InputLabel>Property Type</InputLabel>
-                  <Select
-                    value={formData.propertyType}
-                    onChange={(e) => handleInputChange('propertyType', e.target.value)}
-                    label="Property Type"
-                  >
-                    {Object.values(PropertyType).map((t) => (
-                      <MenuItem key={t} value={t}>{t}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-                <FormControl fullWidth required>
-                  <InputLabel>Listing Type</InputLabel>
-                  <Select
-                    value={formData.listingType}
-                    onChange={(e) => handleInputChange('listingType', e.target.value)}
-                    label="Listing Type"
-                  >
-                    {Object.values(ListingType).map((t) => (
-                      <MenuItem key={t} value={t}>{t}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Box>
+            <Box>
+              <Typography sx={{ fontWeight: 600, fontSize: 13.5, mb: 0.75, color: '#1F2937' }}>
+                Location (Maps integrated)
+              </Typography>
+              <LocationAutocomplete
+                value={formData.location}
+                onChange={(v) => handleInputChange('location', v)}
+                onLocationSelect={handleLocationSelect}
+              />
+            </Box>
 
-              <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 3 }}>
+            <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2 }}>
+              <Box>
+                <Typography sx={{ fontWeight: 600, fontSize: 13.5, mb: 0.75, color: '#1F2937' }}>Builder Name</Typography>
                 <TextField
                   fullWidth
-                  label="Price (INR)"
-                  value={formData.price}
-                  onChange={(e) => handleInputChange('price', e.target.value)}
-                  type="number"
-                  InputProps={{ startAdornment: <PriceIcon sx={{ mr: 1, color: '#6B7280' }} /> }}
+                  placeholder="e.g. Prestige Builders"
+                  value={formData.builderName}
+                  onChange={(e) => handleInputChange('builderName', e.target.value)}
+                  sx={fieldSx}
                 />
-                <Box>
-                  <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>Location *</Typography>
-                  <LocationAutocomplete
-                    onLocationSelect={handleLocationSelect}
-                    value={formData.location}
-                    onChange={(value) => handleInputChange('location', value)}
-                  />
-                </Box>
               </Box>
-
-              <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr 1fr' }, gap: 3 }}>
-                <TextField label="City" value={formData.city} onChange={(e) => handleInputChange('city', e.target.value)} />
-                <TextField label="State" value={formData.state} onChange={(e) => handleInputChange('state', e.target.value)} />
-                <TextField label="Bedrooms" value={formData.bedrooms} onChange={(e) => handleInputChange('bedrooms', e.target.value)} type="number" />
-              </Box>
-
-              <TextField
-                fullWidth
-                label="Description"
-                value={formData.description}
-                onChange={(e) => handleInputChange('description', e.target.value)}
-                multiline
-                rows={4}
-                required
-                InputProps={{ startAdornment: <DescriptionIcon sx={{ mr: 1, color: '#6B7280', alignSelf: 'flex-start', mt: 1 }} /> }}
-              />
-
-              <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
-                <Button variant="outlined" onClick={() => navigate('/home')}>Cancel</Button>
-                <Button type="submit" variant="contained" disabled={loading}>
-                  {loading ? <CircularProgress size={20} color="inherit" /> : 'Create Property'}
-                </Button>
+              <Box>
+                <Typography sx={{ fontWeight: 600, fontSize: 13.5, mb: 0.75, color: '#1F2937' }}>RERA ID (Optional)</Typography>
+                <TextField
+                  fullWidth
+                  placeholder="Enter RERA registration number"
+                  value={formData.reraId}
+                  onChange={(e) => handleInputChange('reraId', e.target.value)}
+                  sx={fieldSx}
+                />
               </Box>
             </Box>
-          </CardContent>
-        </Card>
-      </Container>
 
-      <Snackbar open={snackbar.open} autoHideDuration={6000} onClose={() => setSnackbar((p) => ({ ...p, open: false }))}>
+            <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2 }}>
+              <Box>
+                <Typography sx={{ fontWeight: 600, fontSize: 13.5, mb: 0.75, color: '#1F2937' }}>Property Type</Typography>
+                <TextField
+                  select
+                  fullWidth
+                  value={formData.propertyType}
+                  onChange={(e) => handleInputChange('propertyType', e.target.value)}
+                  SelectProps={{ native: true }}
+                  sx={fieldSx}
+                >
+                  {Object.values(PropertyType).map((t) => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </TextField>
+              </Box>
+              <Box>
+                <Typography sx={{ fontWeight: 600, fontSize: 13.5, mb: 0.75, color: '#1F2937' }}>Price (INR)</Typography>
+                <TextField
+                  fullWidth
+                  type="number"
+                  placeholder="Optional"
+                  value={formData.price}
+                  onChange={(e) => handleInputChange('price', e.target.value)}
+                  sx={fieldSx}
+                />
+              </Box>
+            </Box>
+
+            <Box>
+              <Typography sx={{ fontWeight: 600, fontSize: 13.5, mb: 0.75, color: '#1F2937' }}>Description</Typography>
+              <TextField
+                fullWidth
+                multiline
+                minRows={3}
+                placeholder="Describe amenities, project highlights, and neighborhood"
+                value={formData.description}
+                onChange={(e) => handleInputChange('description', e.target.value)}
+                sx={fieldSx}
+              />
+            </Box>
+
+            <Box>
+              <Typography sx={{ fontWeight: 600, fontSize: 13.5, mb: 0.75, color: '#1F2937' }}>Property Documents</Typography>
+              <Box
+                onClick={() => docInputRef.current?.click()}
+                sx={{
+                  border: '1.5px dashed #D1D5DB',
+                  borderRadius: 2,
+                  py: 3,
+                  px: 2,
+                  textAlign: 'center',
+                  cursor: 'pointer',
+                  bgcolor: '#FAFAFA',
+                  '&:hover': { borderColor: ZPC_COLORS.primary, bgcolor: 'rgba(22,48,42,0.03)' },
+                }}
+              >
+                <PictureAsPdfIcon sx={{ color: '#9CA3AF', fontSize: 36, mb: 0.5 }} />
+                <Typography sx={{ fontSize: 13.5, color: '#4B5563' }}>
+                  Drag and drop documents here, or click to select
+                </Typography>
+                <Typography sx={{ fontSize: 12, color: '#9CA3AF', mt: 0.35 }}>
+                  Supports PDF, DOCX up to 15MB
+                </Typography>
+                <input
+                  ref={docInputRef}
+                  type="file"
+                  hidden
+                  multiple
+                  accept=".pdf,.doc,.docx,application/pdf"
+                  onChange={(e) => {
+                    const files = Array.from(e.target.files || []);
+                    setDocuments((prev) => [...prev, ...files].slice(0, 10));
+                    e.target.value = '';
+                  }}
+                />
+              </Box>
+              {documents.length > 0 && (
+                <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mt: 1 }}>
+                  {documents.map((doc) => (
+                    <Chip
+                      key={doc.name + doc.size}
+                      icon={<InsertDriveFileIcon />}
+                      label={doc.name}
+                      onDelete={() => setDocuments((prev) => prev.filter((d) => d !== doc))}
+                      sx={{ maxWidth: 240 }}
+                    />
+                  ))}
+                </Stack>
+              )}
+            </Box>
+
+            <Box>
+              <Typography sx={{ fontWeight: 600, fontSize: 13.5, mb: 0.75, color: '#1F2937' }}>Property Photos</Typography>
+              <Box
+                onClick={() => photoInputRef.current?.click()}
+                sx={{
+                  border: '1.5px dashed #D1D5DB',
+                  borderRadius: 2,
+                  py: 2.5,
+                  px: 2,
+                  textAlign: 'center',
+                  cursor: 'pointer',
+                  bgcolor: '#FAFAFA',
+                  '&:hover': { borderColor: ZPC_COLORS.primary },
+                }}
+              >
+                <CloudUploadIcon sx={{ color: '#9CA3AF', fontSize: 32 }} />
+                <Typography sx={{ fontSize: 13, color: '#6B7280', mt: 0.5 }}>
+                  Click to select cover & gallery photos
+                </Typography>
+                <input
+                  ref={photoInputRef}
+                  type="file"
+                  hidden
+                  multiple
+                  accept="image/*"
+                  onChange={(e) => {
+                    const files = Array.from(e.target.files || []);
+                    setPhotos((prev) => [...prev, ...files].slice(0, 12));
+                    e.target.value = '';
+                  }}
+                />
+              </Box>
+              {photos.length > 0 && (
+                <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mt: 1 }}>
+                  {photos.map((photo) => (
+                    <Chip
+                      key={photo.name + photo.size}
+                      label={photo.name}
+                      onDelete={() => setPhotos((prev) => prev.filter((p) => p !== photo))}
+                      sx={{ maxWidth: 200 }}
+                    />
+                  ))}
+                </Stack>
+              )}
+            </Box>
+
+            <Alert severity="info" sx={{ borderRadius: 2 }}>
+              Your listing will be submitted for review. Admins will verify details before it goes live.
+            </Alert>
+          </Box>
+
+          <Box
+            sx={{
+              mt: 'auto',
+              px: 3,
+              py: 2,
+              borderTop: '1px solid #E5E7EB',
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: 1.25,
+              flexShrink: 0,
+            }}
+          >
+            <Button
+              variant="outlined"
+              onClick={() => navigate(-1)}
+              disabled={loading}
+              sx={{ textTransform: 'none', borderRadius: 2, px: 2.5, color: '#374151', borderColor: '#D1D5DB' }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={loading}
+              sx={{
+                textTransform: 'none',
+                borderRadius: 2,
+                px: 2.75,
+                bgcolor: ZPC_COLORS.primary,
+                '&:hover': { bgcolor: ZPC_COLORS.primaryHover },
+              }}
+            >
+              {loading ? <CircularProgress size={20} color="inherit" /> : 'Submit Property'}
+            </Button>
+          </Box>
+        </Box>
+      </Fade>
+
+      <Dialog
+        open={showReviewModal}
+        onClose={() => closeReviewModal(false)}
+        fullWidth
+        maxWidth="sm"
+        PaperProps={{ sx: { borderRadius: 3, p: 0.5 } }}
+      >
+        <DialogContent sx={{ textAlign: 'center', pt: 3, pb: 1 }}>
+          <IconButton
+            onClick={() => closeReviewModal(false)}
+            sx={{ position: 'absolute', right: 10, top: 10, bgcolor: '#F3F4F6' }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+          <Box
+            sx={{
+              width: 72,
+              height: 72,
+              borderRadius: '50%',
+              bgcolor: ZPC_COLORS.primary,
+              color: '#EBE6D4',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              mb: 1.5,
+              boxShadow: '0 10px 28px rgba(22,48,42,0.28)',
+            }}
+          >
+            <SendIcon />
+          </Box>
+          <Typography sx={{ fontFamily: ZPC_FONTS.display, fontWeight: 700, fontSize: 22, mb: 1 }}>
+            Property Submitted
+          </Typography>
+          <Chip
+            icon={<AccessTimeIcon sx={{ fontSize: '16px !important' }} />}
+            label="Pending Approval"
+            sx={{
+              bgcolor: '#FEF3C7',
+              color: '#B45309',
+              fontWeight: 700,
+              mb: 1.5,
+              '& .MuiChip-icon': { color: '#B45309' },
+            }}
+          />
+          <Typography sx={{ color: '#4B5563', fontSize: 14, lineHeight: 1.55, mb: 2 }}>
+            Your property has been submitted and is currently <strong>waiting for approval</strong>.
+            You&apos;ll be notified once your Property ID is created and the listing goes live.
+          </Typography>
+
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 1.25,
+              alignItems: 'flex-start',
+              textAlign: 'left',
+              bgcolor: 'rgba(22,48,42,0.06)',
+              borderRadius: 2,
+              p: 1.5,
+              mb: 2.5,
+            }}
+          >
+            <NotificationsActiveIcon sx={{ color: ZPC_COLORS.primary, mt: 0.25 }} />
+            <Typography sx={{ fontSize: 13.5, color: ZPC_COLORS.primary }}>
+              <strong>You&apos;ll receive a notification</strong> — We&apos;ll send a real-time alert as soon as your
+              property is reviewed and your unique Property ID is assigned.
+            </Typography>
+          </Box>
+
+          <Stack spacing={1.75} sx={{ textAlign: 'left', px: 0.5 }}>
+            {[
+              { icon: <CheckCircleIcon sx={{ color: '#fff', fontSize: 18 }} />, bg: ZPC_COLORS.primary, label: 'Property Submitted', right: 'Just now', done: true },
+              { icon: <HourglassTopIcon sx={{ color: '#fff', fontSize: 18 }} />, bg: '#D97706', label: 'Under Review', right: 'In progress', done: false },
+              { icon: <BadgeIcon sx={{ color: '#9CA3AF', fontSize: 18 }} />, bg: '#E5E7EB', label: 'Property ID Created', right: 'Pending', done: false },
+            ].map((step, idx) => (
+              <Box key={step.label} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: '50%',
+                    bgcolor: step.bg,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                  }}
+                >
+                  {step.icon}
+                </Box>
+                <Typography sx={{ flex: 1, fontWeight: 650, color: idx === 2 ? '#9CA3AF' : '#111827', fontSize: 14 }}>
+                  {step.label}
+                </Typography>
+                <Typography sx={{ fontSize: 12.5, color: '#6B7280' }}>{step.right}</Typography>
+              </Box>
+            ))}
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2.5, gap: 1, justifyContent: 'stretch' }}>
+          <Button
+            fullWidth
+            variant="contained"
+            onClick={() => closeReviewModal(true)}
+            sx={{ textTransform: 'none', borderRadius: 2, bgcolor: ZPC_COLORS.primary, py: 1.1 }}
+          >
+            Got it, Thanks!
+          </Button>
+          <Button
+            fullWidth
+            variant="outlined"
+            onClick={() => closeReviewModal(false)}
+            sx={{ textTransform: 'none', borderRadius: 2, borderColor: '#D1D5DB', color: '#374151', py: 1.1 }}
+          >
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar open={snackbar.open} autoHideDuration={5000} onClose={() => setSnackbar((p) => ({ ...p, open: false }))}>
         <Alert severity={snackbar.severity}>{snackbar.message}</Alert>
       </Snackbar>
     </Box>

--- a/src/components/FacebookSignInButton.tsx
+++ b/src/components/FacebookSignInButton.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Button } from '@mui/material';
+import { Button, IconButton, Tooltip, Typography } from '@mui/material';
+import FacebookIcon from '@mui/icons-material/Facebook';
 
 interface FacebookSignInButtonProps {
   onAccessToken: (accessToken: string) => void;
   disabled?: boolean;
   label?: string;
+  /** Full-width labeled button vs compact circular icon. */
+  variant?: 'full' | 'icon';
 }
 
 declare global {
@@ -72,11 +75,13 @@ const FacebookSignInButton: React.FC<FacebookSignInButtonProps> = ({
   onAccessToken,
   disabled = false,
   label = 'Continue with Facebook',
+  variant = 'full',
 }) => {
   const onAccessTokenRef = useRef(onAccessToken);
   const [ready, setReady] = useState(false);
   const [scriptError, setScriptError] = useState('');
   const appId = process.env.REACT_APP_FACEBOOK_APP_ID;
+  const isIcon = variant === 'icon';
 
   useEffect(() => {
     onAccessTokenRef.current = onAccessToken;
@@ -119,10 +124,70 @@ const FacebookSignInButton: React.FC<FacebookSignInButtonProps> = ({
   };
 
   if (!appId) {
+    if (isIcon) {
+      return (
+        <Tooltip title="Configure Facebook App ID">
+          <span>
+            <IconButton disabled sx={{ width: 48, height: 48, bgcolor: '#1877F2', color: '#fff' }}>
+              <FacebookIcon />
+            </IconButton>
+          </span>
+        </Tooltip>
+      );
+    }
     return (
       <Button fullWidth variant="outlined" disabled sx={{ textTransform: 'none', py: 1.25 }}>
         Configure Facebook App ID
       </Button>
+    );
+  }
+
+  if (scriptError && isIcon) {
+    return (
+      <Tooltip title={scriptError}>
+        <span>
+          <IconButton
+            disabled={disabled || !ready}
+            onClick={handleClick}
+            sx={{
+              width: 48,
+              height: 48,
+              bgcolor: '#1877F2',
+              color: '#fff',
+              opacity: 0.7,
+              '&:hover': { bgcolor: '#166FE5' },
+            }}
+            aria-label="Continue with Facebook"
+          >
+            <FacebookIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
+    );
+  }
+
+  if (isIcon) {
+    return (
+      <Tooltip title="Continue with Facebook">
+        <span>
+          <IconButton
+            disabled={disabled || !ready}
+            onClick={handleClick}
+            aria-label="Continue with Facebook"
+            sx={{
+              width: 48,
+              height: 48,
+              bgcolor: '#1877F2',
+              color: '#fff',
+              boxShadow: '0 2px 8px rgba(24,119,242,0.35)',
+              '&:hover': { bgcolor: '#166FE5' },
+              '&.Mui-disabled': { bgcolor: '#1877F2', color: '#fff', opacity: 0.55 },
+            }}
+          >
+            <FacebookIcon sx={{ fontSize: 26 }} />
+          </IconButton>
+        </span>
+      </Tooltip>
     );
   }
 

--- a/src/components/GoogleSignInButton.tsx
+++ b/src/components/GoogleSignInButton.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, IconButton, Tooltip, Typography } from '@mui/material';
 
 type GoogleButtonText = 'signin_with' | 'signup_with' | 'continue_with';
 
@@ -7,6 +7,8 @@ interface GoogleSignInButtonProps {
   onCredential: (credential: string) => void;
   disabled?: boolean;
   text?: GoogleButtonText;
+  /** Full-width labeled Google button vs compact circular icon. */
+  variant?: 'full' | 'icon';
 }
 
 declare global {
@@ -38,6 +40,35 @@ declare global {
 const GOOGLE_SCRIPT_ID = 'google-identity-services-script';
 const GOOGLE_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
 
+/** Official multicolor Google "G" mark — always visible (GIS iframe often clips in small circles). */
+const GoogleGIcon: React.FC<{ size?: number }> = ({ size = 22 }) => (
+  <Box
+    component="svg"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 48 48"
+    sx={{ width: size, height: size, display: 'block' }}
+    aria-hidden
+  >
+    <path
+      fill="#EA4335"
+      d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+    />
+    <path
+      fill="#4285F4"
+      d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+    />
+    <path
+      fill="#34A853"
+      d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+    />
+    <path fill="none" d="M0 0h48v48H0z" />
+  </Box>
+);
+
 const loadGoogleScript = () =>
   new Promise<void>((resolve, reject) => {
     if (window.google?.accounts?.id) {
@@ -66,11 +97,13 @@ const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
   onCredential,
   disabled = false,
   text = 'continue_with',
+  variant = 'full',
 }) => {
   const buttonRef = useRef<HTMLDivElement | null>(null);
   const onCredentialRef = useRef(onCredential);
   const [scriptError, setScriptError] = useState('');
   const clientId = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+  const isIcon = variant === 'icon';
 
   useEffect(() => {
     onCredentialRef.current = onCredential;
@@ -92,14 +125,24 @@ const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
             }
           },
         });
-        window.google.accounts.id.renderButton(buttonRef.current, {
-          theme: 'outline',
-          size: 'large',
-          type: 'standard',
-          shape: 'rectangular',
-          text,
-          width: '100%',
-        });
+        window.google.accounts.id.renderButton(
+          buttonRef.current,
+          isIcon
+            ? {
+                type: 'icon',
+                shape: 'circle',
+                size: 'large',
+                theme: 'outline',
+              }
+            : {
+                theme: 'outline',
+                size: 'large',
+                type: 'standard',
+                shape: 'rectangular',
+                text,
+                width: '100%',
+              }
+        );
       })
       .catch((error) => {
         if (!cancelled) setScriptError(error.message);
@@ -108,21 +151,86 @@ const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [clientId, text]);
+  }, [clientId, text, isIcon]);
 
   if (!clientId) {
     return (
-      <Button fullWidth variant="outlined" disabled sx={{ textTransform: 'none', py: 1.25 }}>
-        Configure Google Client ID
-      </Button>
+      <Tooltip title="Configure Google Client ID">
+        <span>
+          <IconButton
+            disabled
+            size="large"
+            aria-label="Continue with Google"
+            sx={{
+              width: 48,
+              height: 48,
+              bgcolor: '#fff',
+              border: '1px solid rgba(0,0,0,0.12)',
+            }}
+          >
+            <GoogleGIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
     );
   }
 
   if (scriptError) {
     return (
-      <Typography variant="body2" color="error" sx={{ textAlign: 'center' }}>
+      <Typography variant="body2" color="error" sx={{ textAlign: 'center', fontSize: 11 }}>
         {scriptError}
       </Typography>
+    );
+  }
+
+  if (isIcon) {
+    // Always paint our Google "G"; GIS button sits transparent on top for the real click/login.
+    return (
+      <Tooltip title="Continue with Google">
+        <Box
+          sx={{
+            position: 'relative',
+            width: 48,
+            height: 48,
+            borderRadius: '50%',
+            overflow: 'hidden',
+            bgcolor: '#fff',
+            border: '1px solid rgba(0,0,0,0.12)',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+            opacity: disabled ? 0.55 : 1,
+            pointerEvents: disabled ? 'none' : 'auto',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <GoogleGIcon size={22} />
+          <Box
+            ref={buttonRef}
+            aria-hidden
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              opacity: 0.02,
+              cursor: 'pointer',
+              overflow: 'hidden',
+              '& > div': {
+                width: '100% !important',
+                height: '100% !important',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              },
+              '& iframe': {
+                width: '48px !important',
+                height: '48px !important',
+                minWidth: '48px !important',
+              },
+            }}
+          />
+        </Box>
+      </Tooltip>
     );
   }
 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useCallback, memo, useEffect, useRef } from 'react';
 import { gql, useQuery, useMutation, useApolloClient } from '@apollo/client';
-import { SEARCH_POSTS, CREATE_POST, TRENDING_POSTS, DELETE_POST, UPDATE_POST, UPDATE_COMMENT, DELETE_COMMENT, UNLIKE_COMMENT, GET_POST_COMMENTS, CREATE_COMMENT, LIKE_COMMENT, LIKE_POST, UNLIKE_POST, SHARE_POST, REPORT_POST, PIN_POST, UNPIN_POST } from '../graphql/posts';
-import { GET_SUGGESTED_USERS, FOLLOW_USER, GET_USER_NOTIFICATIONS, MARK_NOTIFICATION_READ, GET_USER_PROFILE } from '../graphql/user';
+import { SEARCH_POSTS, CREATE_POST, TRENDING_POSTS, DELETE_POST, UPDATE_POST, UPDATE_COMMENT, DELETE_COMMENT, UNLIKE_COMMENT, GET_POST_COMMENTS, CREATE_COMMENT, LIKE_COMMENT, LIKE_POST, UNLIKE_POST, REPORT_POST, PIN_POST, UNPIN_POST, GET_POST_LIKES } from '../graphql/posts';
+import { GET_SUGGESTED_USERS, FOLLOW_USER, GET_USER_NOTIFICATIONS, MARK_NOTIFICATION_READ, GET_USER_PROFILE, GET_USER_FOLLOWERS, GET_USER_FOLLOWING } from '../graphql/user';
 import CreatePost from './CreatePost';
 import { PostService } from '../services/postService';
 import { useAuth } from '../contexts/AuthContext';
@@ -37,6 +37,11 @@ import {
   Divider,
   TextField,
   Alert,
+  Popover,
+  List,
+  ListItemButton,
+  ListItemAvatar,
+  ListItemText,
 } from '@mui/material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import HomeIcon from '@mui/icons-material/Home';
@@ -50,21 +55,21 @@ import WhatshotIcon from '@mui/icons-material/Whatshot';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import ShareSymbol from './icons/ShareSymbol';
+import SharePostSheet from './SharePostSheet';
+import type { ShareablePost } from '../utils/sharePost';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import PhotoCameraOutlinedIcon from '@mui/icons-material/PhotoCameraOutlined';
-import VideocamOutlinedIcon from '@mui/icons-material/VideocamOutlined';
-import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import StarRoundedIcon from '@mui/icons-material/StarRounded';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ProfilePage from './ProfilePage';
+import TabEnter from './motion/TabEnter';
 import ChatPage from './ChatPage';
-import { MATTE_SURFACE, MATTE_INSET, MATTE_PANEL, PAGE_ATMOSPHERE } from '../theme/surfaces';
+import { MATTE_SURFACE, MATTE_HEADER, MATTE_INSET, MATTE_PANEL, PAGE_ATMOSPHERE } from '../theme/surfaces';
 import AdminBackground from './admin/AdminBackground';
 import { ZpcLogoMark } from './brand/ZpcLogo';
 import PostMediaCarousel from './PostMediaCarousel';
-import { isAdminRole } from '../utils/roles';
+import { canManageProperties as roleCanManageProperties, isAdminRole } from '../utils/roles';
 
 const GRAPHQL_URL = process.env.REACT_APP_GRAPHQL_URL || 'http://localhost:8080/api/v1/graphql';
 const API_GATEWAY_URL = (process.env.REACT_APP_API_GATEWAY_URL || 'http://localhost:8080').replace(/\/$/, '');
@@ -162,12 +167,14 @@ interface PostProps {
   onOpenProfile: (userId: string) => void;
   onEditPost?: (post: PostProps['post']) => void;
   onDeletePost?: (postId: number | string) => void;
-  onSharePost?: (postId: number | string) => void | Promise<void>;
+  onSharePost?: (post: ShareablePost) => void | Promise<void>;
   onReportPost?: (post: PostProps['post']) => void | Promise<void>;
   onPinPost?: (postId: number | string, pin: boolean) => void | Promise<void>;
   /** Live profile photo for the signed-in user (overrides stale post enrichment). */
   viewerProfilePhoto?: string | null;
   currentUserId?: number | string | null;
+  /** User IDs the viewer follows or is followed by — used to filter likers on others' posts. */
+  networkUserIds?: Set<string>;
   likedPosts: { [postId: string]: boolean };
   likeCounts: { [postId: string]: number };
   commentCounts: { [postId: string]: number };
@@ -223,6 +230,7 @@ const Post = memo(({
   onPinPost,
   viewerProfilePhoto = null,
   currentUserId,
+  networkUserIds,
   likedPosts,
   likeCounts,
   commentCounts,
@@ -243,8 +251,22 @@ const Post = memo(({
   setReplyText,
   setReplyingCommentId,
 }: PostProps) => {
+  const client = useApolloClient();
+  const isNarrow = useMediaQuery('(max-width:900px)');
   const [isAnimating, setIsAnimating] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [likersAnchor, setLikersAnchor] = useState<null | HTMLElement>(null);
+  const [likersDialogOpen, setLikersDialogOpen] = useState(false);
+  const [likers, setLikers] = useState<Array<{
+    userId: string;
+    firstName?: string;
+    lastName?: string;
+    userRole?: string;
+    profilePhotoSignedUrl?: string;
+    profilePhoto?: string;
+  }>>([]);
+  const [likersLoading, setLikersLoading] = useState(false);
+  const [likersTotal, setLikersTotal] = useState(0);
   const isOwner = currentUserId != null && String(currentUserId) === String(post.userId);
   const authorName = `${post.userFirstName || ''} ${post.userLastName || ''}`.trim();
   const photoUrl = (() => {
@@ -272,6 +294,37 @@ const Post = memo(({
     post.price != null && Number(post.price) > 0 ? `₹${post.price}` : '',
   ].filter(Boolean);
 
+  const loadLikers = useCallback(async () => {
+    if (!post.id) return;
+    setLikersLoading(true);
+    try {
+      const { data } = await client.query({
+        query: GET_POST_LIKES,
+        variables: { postId: String(post.id), page: 1, limit: 50 },
+        fetchPolicy: 'network-only',
+      });
+      const raw: typeof likers = data?.postLikes?.likes || [];
+      const total = Number(data?.postLikes?.totalCount || 0);
+      const isOwnPost =
+        currentUserId != null && String(currentUserId) === String(post.userId);
+      if (isOwnPost) {
+        setLikers(raw);
+        setLikersTotal(total);
+      } else {
+        const network = networkUserIds || new Set<string>();
+        const visible = raw.filter((u) => network.has(String(u.userId)));
+        setLikers(visible);
+        setLikersTotal(visible.length);
+      }
+    } catch (err) {
+      console.warn('postLikes failed', err);
+      setLikers([]);
+      setLikersTotal(0);
+    } finally {
+      setLikersLoading(false);
+    }
+  }, [client, post.id, post.userId, currentUserId, networkUserIds]);
+
   const handleLikeClick = useCallback(() => {
     setIsAnimating(true);
     setTimeout(() => {
@@ -279,6 +332,83 @@ const Post = memo(({
     }, 600);
     onLikeToggle(post.id);
   }, [post.id, onLikeToggle]);
+
+  const openLikersDesktop = useCallback(
+    (el: HTMLElement) => {
+      if (isNarrow || likeCount <= 0) return;
+      setLikersAnchor(el);
+      void loadLikers();
+    },
+    [isNarrow, likeCount, loadLikers],
+  );
+
+  const openLikersMobile = useCallback(() => {
+    if (!isNarrow || likeCount <= 0) return;
+    setLikersDialogOpen(true);
+    void loadLikers();
+  }, [isNarrow, likeCount, loadLikers]);
+
+  const isOwnPost =
+    currentUserId != null && String(currentUserId) === String(post.userId);
+
+  const likerListContent = (
+    <Box sx={{ minWidth: 260, maxWidth: 320 }}>
+      {likersLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 2.5 }}>
+          <CircularProgress size={22} />
+        </Box>
+      ) : likers.length === 0 ? (
+        <Typography sx={{ px: 2, py: 2, fontSize: 13, color: '#5C675F' }}>
+          {isOwnPost
+            ? 'No likes yet'
+            : 'No one from your network liked this'}
+        </Typography>
+      ) : (
+        <List dense disablePadding sx={{ maxHeight: 320, overflowY: 'auto' }}>
+          {likers.map((u) => {
+            const name = `${u.firstName || ''} ${u.lastName || ''}`.trim() || 'ZPC member';
+            const avatar = u.profilePhotoSignedUrl || u.profilePhoto || '';
+            return (
+              <ListItemButton
+                key={u.userId}
+                onClick={() => {
+                  setLikersAnchor(null);
+                  setLikersDialogOpen(false);
+                  onOpenProfile(String(u.userId));
+                }}
+                sx={{ py: 1, px: 1.5 }}
+              >
+                <ListItemAvatar sx={{ minWidth: 44 }}>
+                  <Avatar
+                    src={avatar || undefined}
+                    sx={{ width: 34, height: 34, bgcolor: stringToColor(name), fontSize: 13 }}
+                  >
+                    {nameInitials(name)}
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary={name}
+                  secondary={u.userRole ? String(u.userRole).replace(/_/g, ' ') : undefined}
+                  primaryTypographyProps={{ fontSize: 14, fontWeight: 600, color: '#0A1210' }}
+                  secondaryTypographyProps={{ fontSize: 12, color: '#5C675F' }}
+                />
+              </ListItemButton>
+            );
+          })}
+        </List>
+      )}
+      {!likersLoading && isOwnPost && likersTotal > likers.length ? (
+        <Typography sx={{ px: 2, pb: 1.25, fontSize: 11.5, color: '#5C675F' }}>
+          Showing {likers.length} of {likersTotal}
+        </Typography>
+      ) : null}
+      {!likersLoading && !isOwnPost && likeCount > likers.length ? (
+        <Typography sx={{ px: 2, pb: 1.25, fontSize: 11.5, color: '#5C675F' }}>
+          Showing people from your network only
+        </Typography>
+      ) : null}
+    </Box>
+  );
 
   const actionBtnSx = {
     flex: 1,
@@ -466,16 +596,42 @@ const Post = memo(({
             pb: 0.35,
           }}
         >
-          <Typography sx={{ fontSize: 12.5, color: '#5C675F', fontWeight: 500 }}>
-            {likeCount > 0 ? (
-              <>
-                <Box component="span" sx={{ mr: 0.5 }} aria-hidden>{liked ? '❤️' : '🤍'}</Box>
-                {likeCount}
-              </>
-            ) : (
-              ' '
-            )}
-          </Typography>
+          {likeCount > 0 ? (
+            <Typography
+              component="button"
+              type="button"
+              onMouseEnter={(e) => openLikersDesktop(e.currentTarget)}
+              onMouseLeave={() => {
+                // Delay so user can move into the popover
+                window.setTimeout(() => {
+                  if (!document.querySelector('[data-likers-popover]:hover')) {
+                    setLikersAnchor(null);
+                  }
+                }, 120);
+              }}
+              onClick={openLikersMobile}
+              sx={{
+                fontSize: 12.5,
+                color: '#5C675F',
+                fontWeight: 500,
+                cursor: 'pointer',
+                border: 'none',
+                background: 'none',
+                p: 0,
+                m: 0,
+                font: 'inherit',
+                display: 'inline-flex',
+                alignItems: 'center',
+                '&:hover': { color: '#16302A', textDecoration: 'underline' },
+              }}
+              aria-label={`${likeCount} likes — view who liked`}
+            >
+              <Box component="span" sx={{ mr: 0.5 }} aria-hidden>{liked ? '❤️' : '🤍'}</Box>
+              {likeCount} {likeCount === 1 ? 'like' : 'likes'}
+            </Typography>
+          ) : (
+            <Typography sx={{ fontSize: 12.5, color: '#5C675F', fontWeight: 500 }}> </Typography>
+          )}
           {commentCount > 0 ? (
             <Typography
               onClick={() => onCommentClick(post.id)}
@@ -492,6 +648,50 @@ const Post = memo(({
           ) : null}
         </Box>
       )}
+
+      <Popover
+        open={Boolean(likersAnchor) && !isNarrow}
+        anchorEl={likersAnchor}
+        onClose={() => setLikersAnchor(null)}
+        disableRestoreFocus
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        PaperProps={{
+          'data-likers-popover': true,
+          onMouseLeave: () => setLikersAnchor(null),
+          sx: {
+            mt: 0.5,
+            borderRadius: 2,
+            ...MATTE_SURFACE,
+            boxShadow: '0 8px 28px rgba(10,18,16,0.14)',
+          },
+        } as any}
+      >
+        <Typography sx={{ px: 1.75, pt: 1.35, pb: 0.5, fontSize: 12.5, fontWeight: 700, color: '#16302A' }}>
+          {isOwnPost ? 'Liked by' : 'Liked by people you know'}
+        </Typography>
+        {likerListContent}
+      </Popover>
+
+      <Dialog
+        open={likersDialogOpen && isNarrow}
+        onClose={() => setLikersDialogOpen(false)}
+        fullWidth
+        maxWidth="xs"
+        PaperProps={{ sx: { borderRadius: 2, ...MATTE_SURFACE } }}
+      >
+        <DialogTitle sx={{ fontSize: 16, fontWeight: 700, color: '#16302A', pb: 0.5 }}>
+          {isOwnPost ? 'Liked by' : 'Liked by people you know'}
+        </DialogTitle>
+        <DialogContent sx={{ px: 0.5, pt: 0.5 }}>
+          {likerListContent}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setLikersDialogOpen(false)} sx={{ textTransform: 'none' }}>
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       <Box
         sx={{
@@ -547,7 +747,13 @@ const Post = memo(({
           sx={actionBtnSx}
           aria-label="Share"
           disabled={(post as any).allowShare === false || !onSharePost}
-          onClick={() => onSharePost?.(post.id)}
+          onClick={() =>
+            onSharePost?.({
+              id: post.id,
+              title: (post as any).title,
+              content: (post as any).content,
+            })
+          }
         >
           Share
         </Button>
@@ -611,7 +817,7 @@ const Post = memo(({
                   setReplyText={setReplyText || (() => {})}
                   setReplyingCommentId={setReplyingCommentId || (() => {})}
                   replying={false}
-                  onReply={(text: string) => onAddComment?.(post.id, text, comment.id)}
+                  onReply={(text: string, parentId: string) => onAddComment?.(post.id, text, parentId)}
                   onReactComment={onReactComment || (() => {})}
                   onEditComment={onEditComment || (() => {})}
                   onDeleteComment={onDeleteComment || (() => {})}
@@ -724,6 +930,33 @@ const Home = () => {
   // Closest live proxy for “who engaged with your profile” until a views API exists.
   const profileViewsApprox = ownFollowers + ownRatings.length;
 
+  const { data: followersData } = useQuery(GET_USER_FOLLOWERS, {
+    variables: { userId: String(activeUserId || '') },
+    skip: !activeUserId,
+    fetchPolicy: 'cache-and-network',
+    errorPolicy: 'ignore',
+  });
+  const { data: followingData } = useQuery(GET_USER_FOLLOWING, {
+    variables: { userId: String(activeUserId || '') },
+    skip: !activeUserId,
+    fetchPolicy: 'cache-and-network',
+    errorPolicy: 'ignore',
+  });
+  const networkUserIds = useMemo(() => {
+    const ids = new Set<string>();
+    const me = activeUserId != null ? String(activeUserId) : '';
+    if (me) ids.add(me);
+    (followersData?.userFollowers || []).forEach((f: any) => {
+      const id = String(f.followerId || '');
+      if (id && id !== me) ids.add(id);
+    });
+    (followingData?.userFollowing || []).forEach((f: any) => {
+      const id = String(f.followingId || '');
+      if (id && id !== me) ids.add(id);
+    });
+    return ids;
+  }, [activeUserId, followersData?.userFollowers, followingData?.userFollowing]);
+
   const { data: notifData, refetch: refetchNotifs } = useQuery(GET_USER_NOTIFICATIONS, {
     variables: { userId: String(activeUserId || ''), page: 1, limit: 20 },
     skip: !activeUserId,
@@ -786,6 +1019,31 @@ const Home = () => {
     window.history.replaceState({}, '');
   }, [location.state, isMobile, navigate]);
 
+  // Deep-link from shared URL: /home?post=<id>
+  useEffect(() => {
+    const params = new URLSearchParams(location.search || '');
+    const postId = params.get('post');
+    if (!postId) return;
+    setCurrentPage('home');
+    setSelectedProfileId(null);
+    if (!data?.searchPosts?.length) return;
+
+    const t = window.setTimeout(() => {
+      const el = document.getElementById(`post-${postId}`);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        el.style.outline = '2px solid #5F8670';
+        el.style.outlineOffset = '4px';
+        window.setTimeout(() => {
+          el.style.outline = '';
+          el.style.outlineOffset = '';
+        }, 2500);
+      }
+      navigate('/home', { replace: true });
+    }, 300);
+    return () => window.clearTimeout(t);
+  }, [location.search, navigate, data?.searchPosts]);
+
   // GraphQL mutations
   const [createComment] = useMutation(CREATE_COMMENT);
   const [likeComment] = useMutation(LIKE_COMMENT);
@@ -797,7 +1055,6 @@ const Home = () => {
   const [createPostMutation] = useMutation(CREATE_POST);
   const [updatePostMutation] = useMutation(UPDATE_POST);
   const [deletePostMutation] = useMutation(DELETE_POST);
-  const [sharePostMutation] = useMutation(SHARE_POST);
   const [reportPostMutation] = useMutation(REPORT_POST);
   const [pinPostMutation] = useMutation(PIN_POST);
   const [unpinPostMutation] = useMutation(UNPIN_POST);
@@ -808,6 +1065,7 @@ const Home = () => {
   const [editTitle, setEditTitle] = useState('');
   const [editContent, setEditContent] = useState('');
   const [editSaving, setEditSaving] = useState(false);
+  const [sharePostTarget, setSharePostTarget] = useState<ShareablePost | null>(null);
 
   // Function to fetch fresh user data from backend
   const fetchAndUpdateUserData = useCallback(async () => {
@@ -1053,18 +1311,19 @@ const Home = () => {
     }
   }, []);
 
-  // Helper function to check if user has property management permissions
+  // Agent & Builder only — Admin/General cannot create or manage listings
   const canManageProperties = useCallback(() => {
     const user = authUser || currentUser || storedUser;
-    if (!user) {
-      return false;
-    }
-    if (!user.role || user.role.trim() === '') {
-      return false;
-    }
-    const userRole = user.role.toLowerCase().trim();
-    return userRole === 'builder' || userRole === 'admin';
+    return roleCanManageProperties(user?.role);
   }, [authUser, currentUser, storedUser]);
+
+  const propertyNav = useMemo(
+    () =>
+      canManageProperties()
+        ? leftNav
+        : leftNav.filter((item) => item.label !== 'Properties'),
+    [canManageProperties]
+  );
 
   const canAccessAdmin = useCallback(() => {
     const user = authUser || currentUser || storedUser;
@@ -1136,7 +1395,7 @@ const Home = () => {
 
       const { data, errors } = await createPostMutation({
         variables: {
-          userId: parseInt(String(user.id), 10),
+          userId: String(user.id),
           title: postData.title,
           content: postData.content,
           visibility: postData.visibility || 'public',
@@ -1149,7 +1408,7 @@ const Home = () => {
           media:
             uploadedMedia.length > 0
               ? uploadedMedia.map((media, index) => ({
-                  mediaType: media.contentType.startsWith('video/') ? 'video' : 'image',
+                  mediaType: media.contentType.startsWith('video/') ? 'VIDEO' : 'IMAGE',
                   mediaOrder: index + 1,
                   filePath: media.url,
                   fileName: media.name,
@@ -1237,31 +1496,14 @@ const Home = () => {
     }
   }, [deletePostMutation, refetch]);
 
-  const handleSharePost = useCallback(async (postId: number | string) => {
-    if (!activeUserId) {
-      window.alert('Please sign in to share posts.');
-      return;
-    }
-    try {
-      const { data: result } = await sharePostMutation({
-        variables: {
-          postId: String(postId),
-          sharedBy: String(activeUserId),
-          shareType: 'SHARE',
-          visibility: 'PUBLIC',
-        },
-      });
-      if (result?.sharePost?.success) {
-        window.alert('Post shared to your activity.');
-        await refetch();
-      } else {
-        window.alert(result?.sharePost?.message || 'Could not share post');
-      }
-    } catch (err) {
-      console.error('Error sharing post:', err);
-      window.alert('Could not share post');
-    }
-  }, [activeUserId, sharePostMutation, refetch]);
+  const handleSharePost = useCallback((post: ShareablePost) => {
+    if ((post as any)?.allowShare === false) return;
+    setSharePostTarget({
+      id: post.id,
+      title: post.title,
+      content: post.content,
+    });
+  }, []);
 
   const handleReportPost = useCallback(async (post: any) => {
     if (!activeUserId) {
@@ -1607,15 +1849,20 @@ const Home = () => {
     }
 
     return (
-      <>
+      <TabEnter tabKey={`profile-${selectedProfileId}`}>
         <ProfilePage
           onGoBack={handleGoHome}
           userId={String(selectedProfileId)}
           currentUserId={authUserId != null ? String(authUserId) : undefined}
           onOpenProfile={handleOpenProfile}
+          onOpenChat={(roomId) => {
+            setChatRoomId(String(roomId));
+            setChatOpen(true);
+          }}
         />
         {!isMobile && chatOpen && (
           <ChatPage
+            key={chatRoomId || 'chat-dock'}
             embedded
             initialRoomId={chatRoomId}
             onClose={() => {
@@ -1624,7 +1871,7 @@ const Home = () => {
             }}
           />
         )}
-      </>
+      </TabEnter>
     );
   }
 
@@ -1639,18 +1886,14 @@ const Home = () => {
       }}
     >
       <AdminBackground />
-      {/* LinkedIn-style top bar — ZPC cream glass */}
+      {/* LinkedIn-style top bar — forest green frosted glass */}
       <AppBar
         position="fixed"
         elevation={0}
         sx={{
-          ...MATTE_SURFACE,
+          ...MATTE_HEADER,
           borderRadius: 0,
-          borderLeft: 'none',
-          borderRight: 'none',
-          borderTop: 'none',
           zIndex: 1201,
-          color: '#16302A',
         }}
       >
         <Toolbar
@@ -1664,11 +1907,12 @@ const Home = () => {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
+            bgcolor: 'transparent',
           }}
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, minWidth: 0, flex: { xs: 1, md: '0 0 auto' } }}>
             {isMobile && (
-              <IconButton edge="start" aria-label="Open menu" onClick={() => setMobileMenuOpen(true)} size="small" sx={{ color: '#16302A' }}>
+              <IconButton edge="start" aria-label="Open menu" onClick={() => setMobileMenuOpen(true)} size="small" sx={{ color: '#EBE6D4' }}>
                 <MenuIcon />
               </IconButton>
             )}
@@ -1681,15 +1925,15 @@ const Home = () => {
                   display: 'flex',
                   alignItems: 'center',
                   gap: 0.75,
-                  bgcolor: 'rgba(22,48,42,0.06)',
+                  bgcolor: 'rgba(235,230,212,0.12)',
                   px: 1.25,
                   py: 0.55,
                   borderRadius: 1,
                   width: 280,
-                  border: '1px solid rgba(22,48,42,0.1)',
+                  border: '1px solid rgba(235,230,212,0.28)',
                 }}
               >
-                <SearchIcon sx={{ color: '#5C675F', fontSize: 18 }} />
+                <SearchIcon sx={{ color: 'rgba(235,230,212,0.75)', fontSize: 18 }} />
                 <InputBase
                   placeholder="Search people, properties, posts"
                   fullWidth
@@ -1701,7 +1945,13 @@ const Home = () => {
                       navigate(q ? `/search?q=${encodeURIComponent(q)}` : '/search');
                     }
                   }}
-                  sx={{ fontSize: 14, color: '#16302A', ...interFont, '& input': { py: 0.25 } }}
+                  sx={{
+                    fontSize: 14,
+                    color: '#EBE6D4',
+                    ...interFont,
+                    '& input': { py: 0.25 },
+                    '& input::placeholder': { color: 'rgba(235,230,212,0.55)', opacity: 1 },
+                  }}
                 />
               </Box>
             )}
@@ -1709,7 +1959,7 @@ const Home = () => {
 
           {!isMobile && (
             <Box sx={{ display: 'flex', alignItems: 'stretch', gap: 0.15, flex: 1, justifyContent: 'center', maxWidth: 720, minWidth: 0 }}>
-              {leftNav.map((item) => {
+              {propertyNav.map((item) => {
                 const active = item.label === 'Home';
                 return (
                   <Box
@@ -1734,9 +1984,9 @@ const Home = () => {
                       py: 0.55,
                       px: 0.35,
                       cursor: 'pointer',
-                      color: active ? '#16302A' : '#5C675F',
-                      borderBottom: active ? '2px solid #16302A' : '2px solid transparent',
-                      '&:hover': { color: '#16302A', bgcolor: 'rgba(22,48,42,0.04)' },
+                      color: active ? '#EBE6D4' : 'rgba(235,230,212,0.72)',
+                      borderBottom: active ? '2px solid #EBE6D4' : '2px solid transparent',
+                      '&:hover': { color: '#EBE6D4', bgcolor: 'rgba(235,230,212,0.1)' },
                       '& .MuiSvgIcon-root': { fontSize: 22 },
                     }}
                   >
@@ -1768,7 +2018,7 @@ const Home = () => {
                   size="small"
                   aria-label="Messages"
                   onClick={() => setChatOpen(true)}
-                  sx={{ color: '#16302A' }}
+                  sx={{ color: '#EBE6D4' }}
                 >
                   <MessageIcon sx={{ fontSize: 24 }} />
                 </IconButton>
@@ -1776,7 +2026,7 @@ const Home = () => {
                   size="small"
                   aria-label="Notifications"
                   onClick={(e) => setNotifAnchor(e.currentTarget)}
-                  sx={{ color: '#16302A' }}
+                  sx={{ color: '#EBE6D4' }}
                 >
                   <Badge badgeContent={unreadCount} color="error" max={9}>
                     <NotificationsIcon sx={{ fontSize: 24 }} />
@@ -1789,7 +2039,7 @@ const Home = () => {
                     setFindFriendsOpen(true);
                     refetchSuggested();
                   }}
-                  sx={{ color: '#16302A' }}
+                  sx={{ color: '#EBE6D4' }}
                 >
                   <PersonAddIcon sx={{ fontSize: 24 }} />
                 </IconButton>
@@ -1797,10 +2047,10 @@ const Home = () => {
             )}
             {isMobile && (
               <>
-                <IconButton size="small" onClick={() => navigate('/chat')} sx={{ color: '#16302A' }}>
+                <IconButton size="small" onClick={() => navigate('/chat')} sx={{ color: '#EBE6D4' }}>
                   <MessageIcon />
                 </IconButton>
-                <IconButton size="small" onClick={(e) => setNotifAnchor(e.currentTarget)} sx={{ color: '#16302A' }}>
+                <IconButton size="small" onClick={(e) => setNotifAnchor(e.currentTarget)} sx={{ color: '#EBE6D4' }}>
                   <Badge badgeContent={unreadCount} color="error" max={9}>
                     <NotificationsIcon />
                   </Badge>
@@ -1812,11 +2062,11 @@ const Home = () => {
                     setFindFriendsOpen(true);
                     refetchSuggested();
                   }}
-                  sx={{ color: '#16302A' }}
+                  sx={{ color: '#EBE6D4' }}
                 >
                   <PersonAddIcon />
                 </IconButton>
-                <IconButton size="small" onClick={() => setMobileDiscoverOpen(true)} sx={{ color: '#16302A' }}>
+                <IconButton size="small" onClick={() => setMobileDiscoverOpen(true)} sx={{ color: '#EBE6D4' }}>
                   <WhatshotIcon />
                 </IconButton>
               </>
@@ -1831,11 +2081,11 @@ const Home = () => {
                 px: 1,
                 py: 0.35,
                 borderRadius: 1,
-                '&:hover': { bgcolor: 'rgba(22,48,42,0.05)' },
+                '&:hover': { bgcolor: 'rgba(235,230,212,0.1)' },
               }}
             >
               <Avatar src={currentUserData?.profileImage || ''} sx={{ width: 28, height: 28 }} />
-              <Box sx={{ display: 'flex', alignItems: 'center', color: '#5C675F', mt: 0.15 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', color: 'rgba(235,230,212,0.78)', mt: 0.15 }}>
                 <Typography sx={{ fontSize: 11, fontWeight: 600, display: { xs: 'none', sm: 'block' } }}>Me</Typography>
                 <ArrowDropDownIcon sx={{ fontSize: 16 }} />
               </Box>
@@ -1875,6 +2125,19 @@ const Home = () => {
                       }
                     }
                     setNotifAnchor(null);
+                    // Open author profile for follower-post / mention notifications when metadata has authorId
+                    try {
+                      const meta = typeof n.metadata === 'string' && n.metadata
+                        ? JSON.parse(n.metadata)
+                        : (n as any).metadata || {};
+                      const authorId = meta?.authorId || meta?.userId;
+                      const t = String(n.type || '').toLowerCase();
+                      if (authorId && (t.includes('follower_post') || t.includes('post') || t.includes('mention'))) {
+                        handleOpenProfile(String(authorId));
+                      }
+                    } catch {
+                      /* ignore bad metadata */
+                    }
                   }}
                 />
               </Box>
@@ -2184,46 +2447,9 @@ const Home = () => {
                 }}
               >
                 <Typography sx={{ fontSize: 14.5, fontWeight: 500, ...interFont }}>
-                  Start a post
+                  Share a post
                 </Typography>
               </Box>
-            </Box>
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-around',
-                mt: 1,
-                pt: 0.5,
-              }}
-            >
-              {[
-                { label: 'Video', icon: <VideocamOutlinedIcon sx={{ color: '#5F8670' }} />, color: '#5F8670' },
-                { label: 'Photo', icon: <PhotoCameraOutlinedIcon sx={{ color: '#3A6B8C' }} />, color: '#3A6B8C' },
-                { label: 'Write article', icon: <ArticleOutlinedIcon sx={{ color: '#A67C52' }} />, color: '#A67C52' },
-              ].map((action) => (
-                <Button
-                  key={action.label}
-                  onClick={() => {
-                    setCpError(null);
-                    setCreateOpen(true);
-                  }}
-                  startIcon={action.icon}
-                  sx={{
-                    textTransform: 'none',
-                    color: '#3A4540',
-                    fontWeight: 650,
-                    fontSize: 13,
-                    borderRadius: 1,
-                    px: 1.25,
-                    py: 0.85,
-                    flex: 1,
-                    '&:hover': { bgcolor: 'rgba(22,48,42,0.06)' },
-                  }}
-                >
-                  {action.label}
-                </Button>
-              ))}
             </Box>
           </Box>
 
@@ -2264,6 +2490,7 @@ const Home = () => {
                   onPinPost={handlePinPost}
                   viewerProfilePhoto={currentUserData?.profileImage || null}
                   currentUserId={activeUserId}
+                  networkUserIds={networkUserIds}
                   likedPosts={likedPosts}
                   likeCounts={likeCounts}
                   commentCounts={commentCounts}
@@ -2409,7 +2636,7 @@ const Home = () => {
           </Box>
           <Typography sx={{ fontSize: 13, color: '#16302A', mb: 2 }}>Menu</Typography>
           <Stack spacing={0.5}>
-            {leftNav.map((item, idx) => (
+            {propertyNav.map((item, idx) => (
               <Box
                 key={idx}
                 onClick={() => {
@@ -2773,6 +3000,7 @@ const Home = () => {
       {/* LinkedIn-style messaging dock on desktop Home */}
       {!isMobile && chatOpen && (
         <ChatPage
+          key={chatRoomId || 'chat-dock'}
           embedded
           initialRoomId={chatRoomId}
           onClose={() => {
@@ -2781,6 +3009,12 @@ const Home = () => {
           }}
         />
       )}
+
+      <SharePostSheet
+        open={!!sharePostTarget}
+        post={sharePostTarget}
+        onClose={() => setSharePostTarget(null)}
+      />
     </Box>
   );
 };

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -632,7 +632,7 @@ const Post = memo(({
 const Home = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user: authUser, isAuthenticated } = useAuth();
+  const { user: authUser, isAuthenticated, clearAuth } = useAuth();
   const { data, loading, error, refetch } = useQuery(SEARCH_POSTS, {
     variables: { page: 1, limit: 10 },
     fetchPolicy: 'cache-and-network',
@@ -1898,10 +1898,8 @@ const Home = () => {
               )}
               <MenuItem
                 onClick={() => {
-                  localStorage.removeItem('user');
-                  localStorage.removeItem('userInfo');
-                  localStorage.removeItem('token');
-                  localStorage.removeItem('refreshToken');
+                  handleClose();
+                  clearAuth();
                   window.location.href = '/';
                 }}
               >
@@ -2443,6 +2441,31 @@ const Home = () => {
                 <span>{item.label}</span>
               </Box>
             ))}
+            <Box
+              onClick={() => {
+                setMobileMenuOpen(false);
+                clearAuth();
+                window.location.href = '/';
+              }}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.75,
+                px: 1.5,
+                py: 1.35,
+                mt: 1.5,
+                borderRadius: 2.5,
+                cursor: 'pointer',
+                fontWeight: 600,
+                color: '#8B2E2E',
+                fontSize: 15,
+                borderTop: '1px solid rgba(22,48,42,0.12)',
+                pt: 2,
+                '&:active': { bgcolor: 'rgba(22,48,42,0.1)' },
+              }}
+            >
+              <span>Logout</span>
+            </Box>
           </Stack>
         </Box>
       </Drawer>

--- a/src/components/LandingAtmosphereLogin.tsx
+++ b/src/components/LandingAtmosphereLogin.tsx
@@ -13,8 +13,7 @@ import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { ZpcLogoMark } from './brand/ZpcLogo';
 import { MagicCard } from './MagicCard';
-import GoogleSignInButton from './GoogleSignInButton';
-import FacebookSignInButton from './FacebookSignInButton';
+import SocialAuthIconsRow from './SocialAuthIconsRow';
 
 type Props = {
   email: string;
@@ -332,46 +331,13 @@ const LandingAtmosphereLogin: React.FC<Props> = ({
                 >
                   or
                 </Divider>
-                {onGoogleCredential && (
-                  <Box>
-                    <GoogleSignInButton
-                      text="continue_with"
-                      disabled={busy}
-                      onCredential={onGoogleCredential}
-                    />
-                  </Box>
-                )}
-                {onFacebookAccessToken && (
-                  <Box>
-                    <FacebookSignInButton
-                      disabled={busy}
-                      onAccessToken={onFacebookAccessToken}
-                    />
-                  </Box>
-                )}
-                {onMobileSignIn && (
-                  <Button
-                    fullWidth
-                    variant="outlined"
-                    disabled={busy}
-                    onClick={onMobileSignIn}
-                    sx={{
-                      fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif',
-                      textTransform: 'none',
-                      borderRadius: '12px',
-                      py: 1.25,
-                      color: CREAM,
-                      borderColor: 'rgba(235,230,212,0.35)',
-                      bgcolor: 'rgba(235,230,212,0.08)',
-                      '&:hover': {
-                        borderColor: 'rgba(235,230,212,0.55)',
-                        bgcolor: 'rgba(235,230,212,0.14)',
-                      },
-                    }}
-                  >
-                    Continue with mobile number
-                  </Button>
-                )}
+                <SocialAuthIconsRow
+                  disabled={busy}
+                  tone="dark"
+                  onGoogleCredential={onGoogleCredential}
+                  onFacebookAccessToken={onFacebookAccessToken}
+                  onMobileSignIn={onMobileSignIn}
+                />
               </>
             )}
 

--- a/src/components/LandingLiquidGlassLogin.tsx
+++ b/src/components/LandingLiquidGlassLogin.tsx
@@ -10,8 +10,7 @@ import {
 } from '@mui/material';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
-import GoogleSignInButton from './GoogleSignInButton';
-import FacebookSignInButton from './FacebookSignInButton';
+import SocialAuthIconsRow from './SocialAuthIconsRow';
 import '../styles/liquidGlass.css';
 
 const VIDEO_SRC = `${process.env.PUBLIC_URL || ''}/media/ZPC_And_caption_also_change_th.mp4`;
@@ -343,65 +342,13 @@ const LandingLiquidGlassLogin: React.FC<Props> = ({
                 <Box className="lg-divider" sx={{ my: 0.35 }}>
                   or
                 </Box>
-
-                {onGoogleCredential && (
-                  <Box
-                    className="liquid-glass"
-                    sx={{
-                      borderRadius: 999,
-                      overflow: 'hidden',
-                      px: 0.5,
-                      py: 0.35,
-                      display: 'flex',
-                      justifyContent: 'center',
-                    }}
-                  >
-                    <GoogleSignInButton
-                      disabled={busy}
-                      onCredential={onGoogleCredential}
-                    />
-                  </Box>
-                )}
-
-                {onFacebookAccessToken && (
-                  <Box
-                    className="liquid-glass"
-                    sx={{
-                      borderRadius: 999,
-                      overflow: 'hidden',
-                      px: 0.5,
-                      py: 0.35,
-                      display: 'flex',
-                      justifyContent: 'center',
-                    }}
-                  >
-                    <FacebookSignInButton
-                      disabled={busy}
-                      onAccessToken={onFacebookAccessToken}
-                    />
-                  </Box>
-                )}
-
-                {onMobileSignIn && (
-                  <Button
-                    type="button"
-                    disabled={busy}
-                    onClick={onMobileSignIn}
-                    className="liquid-glass lg-interactive lg-cta"
-                    fullWidth
-                    sx={{
-                      textTransform: 'none',
-                      color: 'rgba(255,255,255,0.92)',
-                      fontFamily: 'var(--font-display)',
-                      fontSize: 13,
-                      fontWeight: 600,
-                      borderRadius: 999,
-                      py: 1.1,
-                    }}
-                  >
-                    Continue with mobile number
-                  </Button>
-                )}
+                <SocialAuthIconsRow
+                  disabled={busy}
+                  tone="dark"
+                  onGoogleCredential={onGoogleCredential}
+                  onFacebookAccessToken={onFacebookAccessToken}
+                  onMobileSignIn={onMobileSignIn}
+                />
               </>
             )}
 

--- a/src/components/LocationAutocomplete.tsx
+++ b/src/components/LocationAutocomplete.tsx
@@ -87,6 +87,7 @@ const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
   const fetchSuggestionsImmediate = async (input: string) => {
     if (!input.trim()) {
       setSuggestions([]);
+      setLoading(false);
       return;
     }
 
@@ -94,18 +95,18 @@ const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
     setSearchError(null);
 
     try {
-      console.log('Fetching suggestions for:', input); // Debug log
-
-      const { data, errors } = await client.query({
+      const queryPromise = client.query({
         query: OLA_AUTOCOMPLETE_QUERY,
         variables: { input },
-        fetchPolicy: 'no-cache', // Disable caching completely
+        fetchPolicy: 'no-cache',
       });
-
-      console.log('GraphQL Response:', { data, errors }); // Debug log
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('Location search timed out')), 8000);
+      });
+      const { data, errors } = await Promise.race([queryPromise, timeoutPromise]);
 
       if (errors) {
-        throw new Error(errors.map(e => e.message).join(', '));
+        throw new Error(errors.map((e: { message: string }) => e.message).join(', '));
       }
 
       if (data?.olaAutocomplete) {

--- a/src/components/MyProperties.tsx
+++ b/src/components/MyProperties.tsx
@@ -29,8 +29,12 @@ import { Property } from '../types/property';
 import { MATTE_SURFACE, MATTE_HEADER, PAGE_ATMOSPHERE } from '../theme/surfaces';
 
 const statusColor = (status: string) => {
-  switch (status) {
+  switch (String(status || '').toUpperCase()) {
     case 'PUBLISHED': return '#10B981';
+    case 'UNDER_REVIEW':
+    case 'PENDING_VERIFICATION':
+    case 'PENDING': return '#D97706';
+    case 'REJECTED': return '#EF4444';
     case 'DRAFT': return '#6B7280';
     case 'SOLD': return '#EF4444';
     case 'RENTED': return '#F59E0B';

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -4,12 +4,13 @@ import { AnimatedList } from './AnimatedList';
 import { formatRelativeTime } from '../utils/datetime';
 
 export type AppNotification = {
-  id: number;
+  id: number | string;
   title?: string;
   message?: string;
   type?: string;
   read?: boolean;
   createdAt?: string | number | Date;
+  metadata?: string | null;
 };
 
 type Props = {
@@ -21,6 +22,7 @@ function styleForType(type?: string): { icon: string; color: string } {
   const t = (type || '').toLowerCase();
   if (t.includes('mention')) return { icon: '@', color: '#16302A' };
   if (t.includes('like') || t.includes('react')) return { icon: '❤️', color: '#16302A' };
+  if (t.includes('follower_post') || t === 'new_post') return { icon: '📝', color: '#5F8670' };
   if (t.includes('follow')) return { icon: '👤', color: '#A89F84' };
   if (t.includes('comment') || t.includes('reply')) return { icon: '💬', color: '#5F8670' };
   if (t.includes('message') || t.includes('chat')) return { icon: '✉️', color: '#5F8670' };

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -28,6 +28,8 @@ import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import ShareSymbol from './icons/ShareSymbol';
+import SharePostSheet from './SharePostSheet';
+import type { ShareablePost } from '../utils/sharePost';
 import StarIcon from '@mui/icons-material/Star';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import MessageIcon from '@mui/icons-material/Message';
@@ -237,6 +239,8 @@ interface ProfilePageProps {
     userId: string;
     currentUserId?: string;
     onOpenProfile?: (userId: string) => void;
+    /** Preferred when embedded in Home — opens chat dock without a brittle /home navigate */
+    onOpenChat?: (roomId: string) => void;
 }
 
 const GRAPHQL_QUERIES = {
@@ -494,26 +498,60 @@ const GRAPHQL_QUERIES = {
                 addedAt
                 commentedAt
                 editedAt
+                likeCount
                 profilePhoto
                 profilePhotoSignedUrl
                 replies {
-                id
-                postId
-                userId
-                userFirstName
-                userLastName
-                userRole
-                comment
-                parentCommentId
-                status
-                addedAt
-                commentedAt
-                editedAt
-                likeCount
-                profilePhoto
-                profilePhotoSignedUrl
+                    id
+                    postId
+                    userId
+                    userFirstName
+                    userLastName
+                    userRole
+                    comment
+                    parentCommentId
+                    status
+                    addedAt
+                    commentedAt
+                    editedAt
+                    likeCount
+                    profilePhoto
+                    profilePhotoSignedUrl
+                    replies {
+                        id
+                        postId
+                        userId
+                        userFirstName
+                        userLastName
+                        userRole
+                        comment
+                        parentCommentId
+                        status
+                        addedAt
+                        commentedAt
+                        editedAt
+                        likeCount
+                        profilePhoto
+                        profilePhotoSignedUrl
+                        replies {
+                            id
+                            postId
+                            userId
+                            userFirstName
+                            userLastName
+                            userRole
+                            comment
+                            parentCommentId
+                            status
+                            addedAt
+                            commentedAt
+                            editedAt
+                            likeCount
+                            profilePhoto
+                            profilePhotoSignedUrl
+                        }
+                    }
                 }
-                likeCount
             }
         }
     `,
@@ -779,7 +817,7 @@ const apiService = {
 
             console.log('Raw comments data:', data.postComments?.[0]); // Debug first comment
 
-            return (data.postComments || []).map((comment: any) => ({
+            const mapComment = (comment: any): any => ({
                 id: comment.id,
                 postId: comment.postId,
                 userId: comment.userId,
@@ -789,28 +827,16 @@ const apiService = {
                 comment: comment.comment,
                 parentCommentId: comment.parentCommentId,
                 status: comment.status,
-                addedAt: comment.addedAt, // Keep as string, will be converted in component
-                commentedAt: comment.commentedAt, // Keep as string, will be converted in component
+                addedAt: comment.addedAt,
+                commentedAt: comment.commentedAt,
+                editedAt: comment.editedAt,
                 likeCount: comment.likeCount || 0,
                 profilePhoto: comment.profilePhoto,
                 profilePhotoSignedUrl: comment.profilePhotoSignedUrl,
-                replies: (comment.replies || []).map((reply: any) => ({
-                    id: reply.id,
-                    postId: reply.postId,
-                    userId: reply.userId,
-                    userFirstName: reply.userFirstName,
-                    userLastName: reply.userLastName,
-                    userRole: reply.userRole,
-                    comment: reply.comment,
-                    parentCommentId: reply.parentCommentId,
-                    status: reply.status,
-                    addedAt: reply.addedAt, // Keep as string
-                    commentedAt: reply.commentedAt, // Keep as string
-                    likeCount: reply.likeCount || 0,
-                    profilePhoto: reply.profilePhoto,
-                    profilePhotoSignedUrl: reply.profilePhotoSignedUrl,
-                }))
-            }));
+                replies: (comment.replies || []).map(mapComment),
+            });
+
+            return (data.postComments || []).map(mapComment);
         } catch (error) {
             console.error('Error fetching post comments:', error);
             return [];
@@ -978,11 +1004,13 @@ const apiService = {
         return data.createComment;
     },
 };
-const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUserId, onOpenProfile }) => {
+const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUserId, onOpenProfile, onOpenChat }) => {
     const navigate = useNavigate();
-    const { updateUser } = useAuth();
+    const { updateUser, user: authUser } = useAuth();
     const isMobile = useMediaQuery('(max-width:900px)');
     const [createDmRoom] = useMutation(CREATE_DM_ROOM_MUTATION);
+    const [messagingInProgress, setMessagingInProgress] = useState(false);
+    const effectiveCurrentUserId = currentUserId || (authUser?.id != null ? String(authUser.id) : undefined);
     const [deletePostMutation] = useMutation(DELETE_POST);
     const [updatePostMutation] = useMutation(UPDATE_POST);
     const [user, setUser] = useState<UserProfile | null>(null);
@@ -999,6 +1027,7 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
     const [editTitle, setEditTitle] = useState('');
     const [editContent, setEditContent] = useState('');
     const [editSaving, setEditSaving] = useState(false);
+    const [sharePostTarget, setSharePostTarget] = useState<ShareablePost | null>(null);
 
     // Post likes and comments state
     const [likedPosts, setLikedPosts] = useState<{ [postId: string]: boolean }>({});
@@ -1518,21 +1547,17 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
                     position="fixed"
                     elevation={0}
                     sx={{
-                        ...MATTE_SURFACE,
+                        ...MATTE_HEADER,
                         borderRadius: 0,
-                        borderLeft: 'none',
-                        borderRight: 'none',
-                        borderTop: 'none',
                         zIndex: 1201,
-                        color: '#16302A',
                     }}
                 >
-                    <Toolbar sx={{ justifyContent: 'space-between', px: { xs: 1, sm: 2 }, minHeight: { xs: 56, sm: 64 }, gap: 1 }}>
+                    <Toolbar sx={{ justifyContent: 'space-between', px: { xs: 1, sm: 2 }, minHeight: { xs: 56, sm: 64 }, gap: 1, bgcolor: 'transparent' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 0.5, sm: 2 }, minWidth: 0 }}>
-                            <IconButton onClick={onGoBack} size={isMobile ? 'small' : 'medium'} sx={{ color: '#16302A' }}>
+                            <IconButton onClick={onGoBack} size={isMobile ? 'small' : 'medium'} sx={{ color: '#EBE6D4' }}>
                                 <ArrowBackIcon />
                             </IconButton>
-                            <Typography variant="h6" sx={{ fontWeight: 700, color: '#16302A', fontSize: { xs: '1rem', sm: '1.25rem' } }}>
+                            <Typography variant="h6" sx={{ fontWeight: 700, color: '#EBE6D4', fontSize: { xs: '1rem', sm: '1.25rem' } }}>
                                 Profile
                             </Typography>
                         </Box>
@@ -1540,7 +1565,7 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
                             variant="h5"
                             sx={{
                                 fontWeight: 900,
-                                color: '#16302A',
+                                color: '#EBE6D4',
                                 letterSpacing: 1,
                                 fontSize: { xs: 'clamp(0.85rem, 3.5vw, 1.1rem)', sm: '1.5rem' },
                                 whiteSpace: 'nowrap',
@@ -1578,21 +1603,17 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
                 position="fixed"
                 elevation={0}
                 sx={{
-                    ...MATTE_SURFACE,
+                    ...MATTE_HEADER,
                     borderRadius: 0,
-                    borderLeft: 'none',
-                    borderRight: 'none',
-                    borderTop: 'none',
                     zIndex: 1201,
-                    color: '#16302A',
                 }}
             >
                 <Toolbar sx={{ justifyContent: 'space-between', px: { xs: 1, sm: 2 }, minHeight: { xs: 56, sm: 64 }, gap: 1, bgcolor: 'transparent' }}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 0.5, sm: 2 }, minWidth: 0 }}>
-                        <IconButton onClick={onGoBack} size={isMobile ? 'small' : 'medium'} sx={{ color: '#16302A' }}>
+                        <IconButton onClick={onGoBack} size={isMobile ? 'small' : 'medium'} sx={{ color: '#EBE6D4' }}>
                             <ArrowBackIcon />
                         </IconButton>
-                        <Typography variant="h6" sx={{ fontWeight: 700, color: '#16302A', fontSize: { xs: '1rem', sm: '1.25rem' } }}>
+                        <Typography variant="h6" sx={{ fontWeight: 700, color: '#EBE6D4', fontSize: { xs: '1rem', sm: '1.25rem' } }}>
                             Profile
                         </Typography>
                     </Box>
@@ -1604,7 +1625,7 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
                             variant="h5"
                             sx={{
                                 fontWeight: 800,
-                                color: '#16302A',
+                                color: '#EBE6D4',
                                 letterSpacing: 0.2,
                                 fontSize: { xs: 'clamp(0.85rem, 3.5vw, 1.1rem)', sm: '1.25rem' },
                                 whiteSpace: 'nowrap',
@@ -1810,25 +1831,44 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
                                             variant="outlined"
                                             startIcon={<MessageIcon />}
                                             size={isMobile ? 'small' : 'medium'}
+                                            disabled={messagingInProgress}
                                             onClick={async () => {
-                                                if (!currentUserId || !user) return;
+                                                const meId = effectiveCurrentUserId;
+                                                if (!meId) {
+                                                    setSnack({ open: true, message: 'Please log in again to send a message', severity: 'error' });
+                                                    return;
+                                                }
+                                                if (!userId) return;
+                                                setMessagingInProgress(true);
                                                 try {
                                                     const result = await createDmRoom({
                                                         variables: {
-                                                            createdBy: String(currentUserId),
-                                                            userA: String(currentUserId),
+                                                            createdBy: String(meId),
+                                                            userA: String(meId),
                                                             userB: String(userId),
                                                         },
                                                     });
-                                                    const roomId = result.data?.createDmRoom?.roomId;
+                                                    const roomId =
+                                                        result.data?.createDmRoom?.roomId ||
+                                                        (result.data?.createDmRoom as any)?.room_id;
                                                     if (!roomId) {
                                                         setSnack({ open: true, message: 'Failed to start conversation', severity: 'error' });
                                                         return;
                                                     }
-                                                    navigate('/home', { state: { openChat: true, autoSelectRoomId: roomId } });
+                                                    if (onOpenChat && !isMobile) {
+                                                        onOpenChat(String(roomId));
+                                                        return;
+                                                    }
+                                                    if (isMobile) {
+                                                        navigate('/chat', { state: { autoSelectRoomId: String(roomId) } });
+                                                        return;
+                                                    }
+                                                    navigate('/home', { state: { openChat: true, autoSelectRoomId: String(roomId) } });
                                                 } catch (err) {
                                                     console.error('Failed to create DM room', err);
                                                     setSnack({ open: true, message: 'Failed to start conversation', severity: 'error' });
+                                                } finally {
+                                                    setMessagingInProgress(false);
                                                 }
                                             }}
                                             sx={{
@@ -1840,7 +1880,7 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
                                                 flex: { xs: '1 1 auto', sm: '0 0 auto' },
                                             }}
                                         >
-                                            Message
+                                            {messagingInProgress ? 'Opening…' : 'Message'}
                                         </Button>
                                     </>
                                 )}
@@ -2228,6 +2268,14 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
                                         </Button>
                                         <IconButton
                                             aria-label="Share"
+                                            onClick={() =>
+                                                setSharePostTarget({
+                                                    id: post.id,
+                                                    title: (post as any).title,
+                                                    content: (post as any).content,
+                                                })
+                                            }
+                                            disabled={(post as any).allowShare === false}
                                             sx={{
                                                 color: '#64748B',
                                                 borderRadius: 2,
@@ -2588,7 +2636,7 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
                                                 replyText={replyText}
                                                 setReplyText={setReplyText}
                                                 replying={replying}
-                                                onReply={(text: string) => handleAddComment(commentsModalOpen.postId!, text, comment.id)}
+                                                onReply={(text: string, parentId: string) => handleAddComment(commentsModalOpen.postId!, text, parentId)}
                                                 onReactComment={handleReactComment}
                                                 onEditComment={handleEditComment}
                                                 onDeleteComment={handleDeleteComment}
@@ -2815,6 +2863,12 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ onGoBack, userId, currentUser
                 </Button>
             </DialogActions>
         </Dialog>
+
+        <SharePostSheet
+            open={!!sharePostTarget}
+            post={sharePostTarget}
+            onClose={() => setSharePostTarget(null)}
+        />
     </>
     );
 };

--- a/src/components/PropertyPage.tsx
+++ b/src/components/PropertyPage.tsx
@@ -1,50 +1,50 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
+  Alert,
   Box,
-  Typography,
-  Card,
-  CardContent,
   Button,
-  Container,
-  AppBar,
-  Toolbar,
-  IconButton,
   Chip,
   CircularProgress,
-  Snackbar,
-  Alert,
-  Rating,
-  TextField,
+  Container,
   Dialog,
-  DialogTitle,
-  DialogContent,
   DialogActions,
-  List,
-  ListItem,
-  ListItemText,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  LinearProgress,
+  Rating,
+  Snackbar,
+  TextField,
+  Typography,
 } from '@mui/material';
-import {
-  ArrowBack as ArrowBackIcon,
-  LocationOn as LocationIcon,
-  Favorite as FavoriteIcon,
-  FavoriteBorder as FavoriteBorderIcon,
-  Close as CloseIcon,
-} from '@mui/icons-material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import CloseIcon from '@mui/icons-material/Close';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import AddIcon from '@mui/icons-material/Add';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useQuery, useMutation } from '@apollo/client';
-import { useApolloClient } from '@apollo/client';
+import { useMutation, useQuery, useApolloClient } from '@apollo/client';
 import {
+  CREATE_PROPERTY_RATING,
   GET_PROPERTY,
   GET_PROPERTY_RATINGS,
-  CREATE_PROPERTY_RATING,
-  SAVE_PROPERTY,
   REMOVE_SAVED_PROPERTY,
+  SAVE_PROPERTY,
 } from '../graphql/property';
 import { Property, PropertyRating } from '../types/property';
 import { PropertyService } from '../services/propertyService';
 import { useAuth } from '../contexts/AuthContext';
-import { MATTE_SURFACE, MATTE_HEADER, PAGE_ATMOSPHERE } from '../theme/surfaces';
+import { MATTE_SURFACE, PAGE_ATMOSPHERE } from '../theme/surfaces';
+import { ZPC_COLORS, ZPC_FONTS } from '../theme/zpcTheme';
 import ShareSymbol from './icons/ShareSymbol';
+
+const COVER_FALLBACK =
+  'https://images.unsplash.com/photo-1545324418-cc1a3fa10c00?w=1400&h=420&fit=crop';
 
 const PropertyPage: React.FC = () => {
   const navigate = useNavigate();
@@ -58,7 +58,11 @@ const PropertyPage: React.FC = () => {
   const [ratingValue, setRatingValue] = useState<number | null>(null);
   const [ratingTitle, setRatingTitle] = useState('');
   const [ratingReview, setRatingReview] = useState('');
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' as 'success' | 'error' | 'info' });
+  const [snackbar, setSnackbar] = useState({
+    open: false,
+    message: '',
+    severity: 'success' as 'success' | 'error' | 'info',
+  });
 
   const { loading, error, data } = useQuery(GET_PROPERTY, {
     variables: { propertyId: propertyId || '' },
@@ -83,8 +87,41 @@ const PropertyPage: React.FC = () => {
 
   const property: Property | undefined = data?.property;
   const ratings: PropertyRating[] = ratingsData?.propertyRatings || [];
+  const isOwner = !!user?.id && !!property?.createdBy && String(user.id) === String(property.createdBy);
+  const underReview = ['UNDER_REVIEW', 'PENDING_VERIFICATION', 'PENDING'].includes(
+    String(property?.status || '').toUpperCase()
+  ) || String(property?.verificationStatus || '').toUpperCase() === 'UNDER_REVIEW';
+
+  const documentFeatures = useMemo(() => {
+    // Features aren't on GET_PROPERTY yet — parse from description lines until get-media exists
+    const lines = String(property?.description || '').split('\n');
+    const docs: string[] = [];
+    for (const line of lines) {
+      if (line.toLowerCase().startsWith('documents attached:')) {
+        docs.push(
+          ...line
+            .slice('documents attached:'.length)
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        );
+      }
+    }
+    return docs;
+  }, [property?.description]);
+
+  const ratingBuckets = useMemo(() => {
+    const counts = [0, 0, 0, 0, 0];
+    ratings.forEach((r) => {
+      const star = Math.min(5, Math.max(1, Math.round(r.overallRating || 0)));
+      counts[5 - star] += 1;
+    });
+    const total = ratings.length || 1;
+    return counts.map((c, i) => ({ stars: 5 - i, pct: Math.round((c / total) * 100), count: c }));
+  }, [ratings]);
 
   const formatPrice = (price: number) => {
+    if (!price) return 'Price on request';
     if (price >= 10000000) return `₹${(price / 10000000).toFixed(1)}Cr`;
     if (price >= 100000) return `₹${(price / 100000).toFixed(1)}L`;
     return `₹${price.toLocaleString()}`;
@@ -150,72 +187,282 @@ const PropertyPage: React.FC = () => {
     );
   }
 
+  const locationLabel = [property.city, property.state].filter(Boolean).join(', ') || 'Location TBD';
+  const builder = property.builderName || `${property.creatorFirstName || ''} ${property.creatorLastName || ''}`.trim() || 'Builder';
+
   return (
-    <Box sx={{ minHeight: '100vh', ...PAGE_ATMOSPHERE }}>
-      <AppBar position="static" elevation={0} sx={{ ...MATTE_HEADER }}>
-        <Toolbar>
-          <IconButton onClick={() => navigate(-1)} sx={{ mr: 2 }}><ArrowBackIcon /></IconButton>
-          <Typography variant="h6" sx={{ flex: 1, fontWeight: 600 }}>{property.title}</Typography>
-          <IconButton onClick={() => navigator.clipboard.writeText(window.location.href)}><ShareSymbol /></IconButton>
-          <IconButton onClick={handleSaveToggle}>
+    <Box sx={{ minHeight: '100vh', bgcolor: '#F1F5F4', animation: 'zpcPageIn 340ms cubic-bezier(0.22,1,0.36,1) both' }}>
+      {/* Cover */}
+      <Box sx={{ position: 'relative', height: { xs: 180, sm: 260 }, overflow: 'hidden' }}>
+        <Box
+          component="img"
+          src={COVER_FALLBACK}
+          alt=""
+          sx={{ width: '100%', height: '100%', objectFit: 'cover', filter: 'saturate(0.85)' }}
+        />
+        <Box sx={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(10,18,16,0.25) 0%, rgba(10,18,16,0.05) 50%, rgba(241,245,244,1) 100%)' }} />
+        <IconButton
+          onClick={() => navigate(-1)}
+          sx={{ position: 'absolute', top: 12, left: 12, bgcolor: 'rgba(255,255,255,0.88)', '&:hover': { bgcolor: '#fff' } }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <Box sx={{ position: 'absolute', top: 12, right: 12, display: 'flex', gap: 0.75 }}>
+          <IconButton onClick={() => navigator.clipboard.writeText(window.location.href)} sx={{ bgcolor: 'rgba(255,255,255,0.88)' }}>
+            <ShareSymbol />
+          </IconButton>
+          <IconButton onClick={handleSaveToggle} sx={{ bgcolor: 'rgba(255,255,255,0.88)' }}>
             {saved ? <FavoriteIcon sx={{ color: '#EF4444' }} /> : <FavoriteBorderIcon />}
           </IconButton>
-        </Toolbar>
-      </AppBar>
+        </Box>
+      </Box>
 
-      <Container maxWidth="lg" sx={{ py: 4 }}>
-        <Card sx={{ borderRadius: 3, ...MATTE_SURFACE, mb: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}>
-              <Chip label={property.status} size="small" />
-              <Chip label={property.verificationStatus} size="small" variant="outlined" />
-              <Chip label={property.listingType} size="small" variant="outlined" />
+      <Container maxWidth="lg" sx={{ mt: { xs: -4, sm: -6 }, pb: 6, position: 'relative', zIndex: 1 }}>
+        {/* Title card */}
+        <Box
+          sx={{
+            ...MATTE_SURFACE,
+            bgcolor: '#fff',
+            borderRadius: 3,
+            p: { xs: 2, sm: 2.5 },
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 2,
+            alignItems: 'center',
+            mb: 2,
+            boxShadow: '0 10px 30px rgba(10,18,16,0.08)',
+          }}
+        >
+          <Box
+            component="img"
+            src={COVER_FALLBACK}
+            alt=""
+            sx={{ width: 84, height: 84, borderRadius: 2, objectFit: 'cover', flexShrink: 0 }}
+          />
+          <Box sx={{ flex: 1, minWidth: 200 }}>
+            <Box sx={{ display: 'flex', gap: 1, mb: 0.75, flexWrap: 'wrap' }}>
+              {underReview && (
+                <Chip label="Under Review" size="small" sx={{ bgcolor: '#FEF3C7', color: '#B45309', fontWeight: 700 }} />
+              )}
+              <Chip label={property.status} size="small" variant="outlined" />
+              <Chip label={property.listingType || 'Listing'} size="small" variant="outlined" />
             </Box>
-            <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>{property.title}</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>{property.propertyCode}</Typography>
-            <Typography variant="h4" sx={{ color: '#10B981', fontWeight: 700, mb: 2 }}>
-              {formatPrice(property.price)} {property.currency}
+            <Typography sx={{ fontFamily: ZPC_FONTS.display, fontWeight: 700, fontSize: { xs: 20, sm: 24 }, color: ZPC_COLORS.primary }}>
+              {property.title}
             </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-              <LocationIcon sx={{ mr: 1, color: '#6B7280' }} />
-              <Typography color="text.secondary">
-                {[property.city, property.state, property.country].filter(Boolean).join(', ')}
+            <Typography sx={{ color: '#6B7280', fontSize: 13, mt: 0.35, textTransform: 'uppercase', letterSpacing: 0.4 }}>
+              {builder}
+            </Typography>
+            <Typography sx={{ color: '#6B7280', fontSize: 13.5, display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.35 }}>
+              <LocationOnIcon sx={{ fontSize: 16 }} /> {locationLabel}
+            </Typography>
+            <Typography sx={{ color: '#9CA3AF', fontSize: 12.5, mt: 0.25 }}>
+              {property.propertyType || 'Residential Project'} · {formatPrice(property.price)}
+            </Typography>
+          </Box>
+          {isOwner && (
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              <Button variant="outlined" sx={{ textTransform: 'none', borderRadius: 2 }} disabled>
+                Change Photo
+              </Button>
+              <Button
+                variant="contained"
+                sx={{ textTransform: 'none', borderRadius: 2, bgcolor: ZPC_COLORS.primary }}
+                onClick={() => setSnackbar({ open: true, message: 'Edit details coming soon', severity: 'info' })}
+              >
+                Edit Details
+              </Button>
+            </Box>
+          )}
+        </Box>
+
+        {/* Stats */}
+        <Box
+          sx={{
+            bgcolor: '#fff',
+            borderRadius: 3,
+            display: 'grid',
+            gridTemplateColumns: 'repeat(4, 1fr)',
+            mb: 2.5,
+            overflow: 'hidden',
+            boxShadow: '0 4px 16px rgba(10,18,16,0.05)',
+          }}
+        >
+          {[
+            { value: String(property.saveCount ?? 0), label: 'Followers' },
+            { value: property.reraId?.trim() || '—', label: 'RERA NO' },
+            { value: property.averageRating ? property.averageRating.toFixed(1) : 'N/A', label: 'Rating' },
+            { value: String(property.ratingCount ?? ratings.length), label: 'Reviews' },
+          ].map((stat, idx) => (
+            <Box
+              key={stat.label}
+              sx={{
+                py: 2,
+                px: 1,
+                textAlign: 'center',
+                borderRight: idx < 3 ? '1px solid #E5E7EB' : 'none',
+              }}
+            >
+              <Typography sx={{ fontWeight: 800, color: ZPC_COLORS.primary, fontSize: { xs: 14, sm: 18 }, wordBreak: 'break-all' }}>
+                {stat.value}
+              </Typography>
+              <Typography sx={{ color: '#9CA3AF', fontSize: 12, mt: 0.25 }}>{stat.label}</Typography>
+            </Box>
+          ))}
+        </Box>
+
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1.7fr 1fr' }, gap: 2.5 }}>
+          <Box sx={{ display: 'grid', gap: 2.5 }}>
+            {/* Documents */}
+            <Box sx={{ bgcolor: '#fff', borderRadius: 3, p: 2.25, boxShadow: '0 4px 16px rgba(10,18,16,0.05)' }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1.75 }}>
+                <Typography sx={{ fontWeight: 700, color: ZPC_COLORS.primary, fontFamily: ZPC_FONTS.display }}>
+                  Property Documents
+                </Typography>
+                {isOwner && (
+                  <Button size="small" startIcon={<AddIcon />} sx={{ textTransform: 'none' }} disabled>
+                    Add Document
+                  </Button>
+                )}
+              </Box>
+              {documentFeatures.length === 0 ? (
+                <Typography sx={{ color: '#9CA3AF', fontSize: 13.5, mb: 1.5 }}>No documents uploaded yet.</Typography>
+              ) : (
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.25, mb: 1.5 }}>
+                  {documentFeatures.map((name) => (
+                    <Box
+                      key={name}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        border: '1px solid #E5E7EB',
+                        borderRadius: 2,
+                        px: 1.25,
+                        py: 1,
+                        minWidth: 180,
+                      }}
+                    >
+                      {name.toLowerCase().includes('pdf') ? (
+                        <PictureAsPdfIcon sx={{ color: '#DC2626' }} />
+                      ) : (
+                        <InsertDriveFileIcon sx={{ color: ZPC_COLORS.primary }} />
+                      )}
+                      <Typography sx={{ fontSize: 13, fontWeight: 600 }} noWrap>{name}</Typography>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+              <Box
+                sx={{
+                  border: '1.5px dashed #D1D5DB',
+                  borderRadius: 2,
+                  py: 2.5,
+                  textAlign: 'center',
+                  color: '#9CA3AF',
+                }}
+              >
+                <CloudUploadIcon />
+                <Typography sx={{ fontSize: 13 }}>Upload New</Typography>
+              </Box>
+            </Box>
+
+            {/* Updates */}
+            <Box sx={{ bgcolor: '#fff', borderRadius: 3, p: 2.25, boxShadow: '0 4px 16px rgba(10,18,16,0.05)', minHeight: 220 }}>
+              <Typography sx={{ fontWeight: 700, color: ZPC_COLORS.primary, fontFamily: ZPC_FONTS.display, mb: 3 }}>
+                Updates
+              </Typography>
+              <Box sx={{ textAlign: 'center', py: 3 }}>
+                <Typography sx={{ fontWeight: 750, color: '#111827', mb: 0.75 }}>No Updates Yet</Typography>
+                <Typography sx={{ color: '#9CA3AF', fontSize: 13.5, mb: 2 }}>
+                  You haven&apos;t posted any updates for this property yet.
+                </Typography>
+                {isOwner && (
+                  <Button
+                    variant="outlined"
+                    sx={{ textTransform: 'none', borderRadius: 2, borderColor: ZPC_COLORS.primary, color: ZPC_COLORS.primary }}
+                    onClick={() => navigate('/home')}
+                  >
+                    Create Post
+                  </Button>
+                )}
+              </Box>
+            </Box>
+
+            {/* Description */}
+            <Box sx={{ bgcolor: '#fff', borderRadius: 3, p: 2.25, boxShadow: '0 4px 16px rgba(10,18,16,0.05)' }}>
+              <Typography sx={{ fontWeight: 700, color: ZPC_COLORS.primary, fontFamily: ZPC_FONTS.display, mb: 1 }}>
+                About
+              </Typography>
+              <Typography sx={{ color: '#4B5563', lineHeight: 1.7, whiteSpace: 'pre-wrap', fontSize: 14 }}>
+                {property.description || 'No description provided.'}
               </Typography>
             </Box>
-            <Typography sx={{ mb: 3, lineHeight: 1.7 }}>{property.description}</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Listed by {property.creatorFirstName} {property.creatorLastName} · {property.viewCount} views · {property.saveCount} saves
-            </Typography>
-          </CardContent>
-        </Card>
+          </Box>
 
-        <Card sx={{ borderRadius: 3, ...MATTE_SURFACE }}>
-          <CardContent sx={{ p: 4 }}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-              <Typography variant="h6" sx={{ fontWeight: 700 }}>Reviews</Typography>
-              <Button variant="contained" onClick={() => setRatingDialogOpen(true)}>Add Review</Button>
-            </Box>
-            <Rating value={property.averageRating} readOnly precision={0.5} sx={{ mb: 2 }} />
-            <List>
-              {ratings.map((r) => (
-                <ListItem key={r.id} alignItems="flex-start" sx={{ flexDirection: 'column', alignItems: 'stretch', mb: 1, bgcolor: 'rgba(0,0,0,0.02)', borderRadius: 2 }}>
-                  <ListItemText
-                    primary={r.title || 'Review'}
-                    secondary={
-                      <>
-                        <Rating value={r.overallRating} readOnly size="small" />
-                        <Typography variant="body2" sx={{ mt: 1 }}>{r.review}</Typography>
-                      </>
-                    }
+          {/* Ratings sidebar */}
+          <Box sx={{ bgcolor: '#fff', borderRadius: 3, p: 2.25, boxShadow: '0 4px 16px rgba(10,18,16,0.05)', alignSelf: 'start' }}>
+            <Typography sx={{ fontWeight: 700, color: ZPC_COLORS.primary, fontFamily: ZPC_FONTS.display, mb: 1.5 }}>
+              Ratings & Reviews
+            </Typography>
+            <Typography sx={{ fontSize: 36, fontWeight: 800, color: ZPC_COLORS.primary, lineHeight: 1 }}>
+              {property.averageRating ? property.averageRating.toFixed(1) : 'N/A'}
+            </Typography>
+            <Rating
+              value={property.averageRating || 0}
+              readOnly
+              precision={0.5}
+              emptyIcon={<StarBorderIcon fontSize="inherit" />}
+              sx={{ my: 0.75 }}
+            />
+            <Typography sx={{ color: '#9CA3AF', fontSize: 12.5, mb: 2 }}>
+              Based on {property.ratingCount ?? ratings.length} reviews
+            </Typography>
+
+            <Box sx={{ display: 'grid', gap: 1, mb: 2 }}>
+              {ratingBuckets.map((b) => (
+                <Box key={b.stars} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Typography sx={{ width: 42, fontSize: 12, color: '#6B7280' }}>{b.stars} star</Typography>
+                  <LinearProgress
+                    variant="determinate"
+                    value={ratings.length ? b.pct : 0}
+                    sx={{
+                      flex: 1,
+                      height: 6,
+                      borderRadius: 99,
+                      bgcolor: '#E5E7EB',
+                      '& .MuiLinearProgress-bar': { bgcolor: ZPC_COLORS.primary, borderRadius: 99 },
+                    }}
                   />
-                </ListItem>
+                  <Typography sx={{ width: 32, fontSize: 12, color: '#9CA3AF', textAlign: 'right' }}>{b.pct}%</Typography>
+                </Box>
               ))}
-              {ratings.length === 0 && (
-                <Typography color="text.secondary">No reviews yet.</Typography>
-              )}
-            </List>
-          </CardContent>
-        </Card>
+            </Box>
+
+            <Button
+              fullWidth
+              variant="contained"
+              onClick={() => setRatingDialogOpen(true)}
+              sx={{ textTransform: 'none', borderRadius: 2, bgcolor: ZPC_COLORS.primary, mb: 2 }}
+            >
+              Add Review
+            </Button>
+
+            {ratings.length === 0 ? (
+              <Typography sx={{ textAlign: 'center', color: '#9CA3AF', fontSize: 13, py: 1 }}>No reviews yet.</Typography>
+            ) : (
+              <Box sx={{ display: 'grid', gap: 1.25, maxHeight: 320, overflow: 'auto' }}>
+                {ratings.map((r) => (
+                  <Box key={r.id} sx={{ border: '1px solid #E5E7EB', borderRadius: 2, p: 1.25 }}>
+                    <Rating value={r.overallRating} readOnly size="small" />
+                    <Typography sx={{ fontWeight: 650, fontSize: 13.5, mt: 0.35 }}>{r.title || 'Review'}</Typography>
+                    <Typography sx={{ color: '#6B7280', fontSize: 13 }}>{r.review}</Typography>
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </Box>
+        </Box>
       </Container>
 
       <Dialog open={ratingDialogOpen} onClose={() => setRatingDialogOpen(false)} fullWidth maxWidth="sm">

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -19,19 +19,15 @@ import {
 import {
   ArrowBack,
   BusinessCenter,
-  Home,
-  MapOutlined,
   AccountCircle,
   CheckCircle,
 } from '@mui/icons-material';
 import ApartmentIcon from '@mui/icons-material/Apartment';
-import BalanceIcon from '@mui/icons-material/Balance';
 import { useAuth } from '../contexts/AuthContext';
 import { AuthService } from '../services/authService';
 import { useApolloClient } from '@apollo/client';
 import LocationAutocomplete from './LocationAutocomplete';
-import GoogleSignInButton from './GoogleSignInButton';
-import FacebookSignInButton from './FacebookSignInButton';
+import SocialAuthIconsRow from './SocialAuthIconsRow';
 import { COUNTRY_CODES } from '../constants/countryCodes';
 import { MagicCard } from './MagicCard';
 import { PAGE_ATMOSPHERE } from '../theme/surfaces';
@@ -42,37 +38,19 @@ const ACCENT_SOFT = 'rgba(143, 169, 152, 0.35)';
 
 const professionOptions = [
   {
-    id: 'builder',
-    label: 'Builder',
-    hint: 'Develop & list projects',
-    icon: ApartmentIcon,
-  },
-  {
     id: 'agent',
     label: 'Agent',
     hint: 'Sell & lease properties',
     icon: BusinessCenter,
   },
   {
-    id: 'buyer_renter',
-    label: 'Buy / Rent',
-    hint: 'Looking for a home',
-    icon: Home,
+    id: 'builder',
+    label: 'Builder',
+    hint: 'Develop & list projects',
+    icon: ApartmentIcon,
   },
   {
-    id: 'litigation_lawyer',
-    label: 'Lawyer',
-    hint: 'Property litigation',
-    icon: BalanceIcon,
-  },
-  {
-    id: 'land_surveyor',
-    label: 'Surveyor',
-    hint: 'Land & site surveys',
-    icon: MapOutlined,
-  },
-  {
-    id: 'general_user',
+    id: 'general',
     label: 'General',
     hint: 'Explore & discuss',
     icon: AccountCircle,
@@ -606,8 +584,8 @@ const Register = () => {
               <Box
                 sx={{
                   display: 'grid',
-                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
-                  gap: 1.25,
+                  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+                  gap: { xs: 0.85, sm: 1.25 },
                   mb: 2.5,
                 }}
               >
@@ -633,10 +611,13 @@ const Register = () => {
                       sx={{
                         position: 'relative',
                         display: 'flex',
+                        flexDirection: 'column',
                         alignItems: 'center',
-                        gap: 1.25,
-                        px: 1.5,
-                        py: 1.35,
+                        textAlign: 'center',
+                        gap: 0.75,
+                        px: { xs: 0.75, sm: 1.25 },
+                        py: { xs: 1.15, sm: 1.35 },
+                        minWidth: 0,
                         borderRadius: '14px',
                         cursor: 'pointer',
                         border: selected
@@ -650,10 +631,21 @@ const Register = () => {
                         },
                       }}
                     >
+                      {selected && (
+                        <CheckCircle
+                          sx={{
+                            color: ACCENT,
+                            fontSize: 16,
+                            position: 'absolute',
+                            top: 6,
+                            right: 6,
+                          }}
+                        />
+                      )}
                       <Box
                         sx={{
-                          width: 40,
-                          height: 40,
+                          width: { xs: 34, sm: 40 },
+                          height: { xs: 34, sm: 40 },
                           borderRadius: '12px',
                           display: 'flex',
                           alignItems: 'center',
@@ -663,14 +655,14 @@ const Register = () => {
                           color: selected ? '#EBE6D4' : ACCENT,
                         }}
                       >
-                        <Icon sx={{ fontSize: 22 }} />
+                        <Icon sx={{ fontSize: { xs: 18, sm: 22 } }} />
                       </Box>
-                      <Box sx={{ minWidth: 0, flex: 1 }}>
+                      <Box sx={{ minWidth: 0, width: '100%' }}>
                         <Typography
                           sx={{
                             fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif',
                             fontWeight: 700,
-                            fontSize: 14,
+                            fontSize: { xs: 12.5, sm: 14 },
                             color: '#0A1210',
                             lineHeight: 1.2,
                           }}
@@ -680,18 +672,16 @@ const Register = () => {
                         <Typography
                           sx={{
                             fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif',
-                            fontSize: 11.5,
+                            fontSize: { xs: 10, sm: 11.5 },
                             fontWeight: 500,
                             color: '#3A4540',
-                            mt: 0.2,
+                            mt: 0.25,
+                            lineHeight: 1.25,
                           }}
                         >
                           {profession.hint}
                         </Typography>
                       </Box>
-                      {selected && (
-                        <CheckCircle sx={{ color: ACCENT, fontSize: 20, flexShrink: 0 }} />
-                      )}
                     </Box>
                   );
                 })}
@@ -763,38 +753,13 @@ const Register = () => {
               </Divider>
 
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
-                <GoogleSignInButton
-                  text="continue_with"
+                <SocialAuthIconsRow
                   disabled={socialAuthDisabled}
-                  onCredential={handleGoogleCredential}
+                  tone="light"
+                  onGoogleCredential={handleGoogleCredential}
+                  onFacebookAccessToken={handleFacebookAccessToken}
+                  onMobileSignIn={() => setMobileSignInOpen(true)}
                 />
-                <FacebookSignInButton
-                  label="Continue with Facebook"
-                  disabled={socialAuthDisabled}
-                  onAccessToken={handleFacebookAccessToken}
-                />
-                <Button
-                  fullWidth
-                  variant="outlined"
-                  disabled={socialAuthDisabled}
-                  onClick={() => setMobileSignInOpen(true)}
-                  sx={{
-                    textTransform: 'none',
-                    py: 1.25,
-                    borderRadius: '12px',
-                    fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif',
-                    fontWeight: 600,
-                    borderColor: 'rgba(22, 48, 42, 0.35)',
-                    color: ACCENT,
-                    bgcolor: 'rgba(235,230,212,0.5)',
-                    '&:hover': {
-                      borderColor: ACCENT,
-                      bgcolor: 'rgba(235,230,212,0.85)',
-                    },
-                  }}
-                >
-                  Continue with mobile number
-                </Button>
               </Box>
 
               <Box sx={{ textAlign: 'center', mt: 2 }}>

--- a/src/components/SearchPage.tsx
+++ b/src/components/SearchPage.tsx
@@ -29,9 +29,10 @@ import PeopleIcon from '@mui/icons-material/People';
 import HomeWorkOutlinedIcon from '@mui/icons-material/HomeWorkOutlined';
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import { SEARCH_USERS_LIGHT } from '../graphql/user';
-import { SEARCH_POSTS } from '../graphql/posts';
+import { SEARCH_POSTS_LIGHT } from '../graphql/posts';
 import { PUBLIC_PROPERTIES } from '../graphql/property';
-import { MATTE_PANEL, MATTE_SURFACE, PAGE_ATMOSPHERE } from '../theme/surfaces';
+import TabEnter from './motion/TabEnter';
+import { MATTE_PANEL, MATTE_SURFACE, MATTE_HEADER, PAGE_ATMOSPHERE } from '../theme/surfaces';
 import AdminBackground from './admin/AdminBackground';
 import { ZpcLogoMark } from './brand/ZpcLogo';
 import { nameInitials, stringToColor } from '../utils/mentions';
@@ -44,10 +45,9 @@ type SearchTab = 'all' | 'people' | 'properties' | 'posts';
 
 const ROLE_OPTIONS = [
   { value: '', label: 'Any role' },
-  { value: 'builder', label: 'Builder' },
   { value: 'agent', label: 'Agent' },
-  { value: 'general_user', label: 'General user' },
-  { value: 'admin', label: 'Admin' },
+  { value: 'builder', label: 'Builder' },
+  { value: 'general', label: 'General' },
 ];
 
 const PROPERTY_TYPES = [
@@ -103,7 +103,7 @@ const SearchPage: React.FC = () => {
   const hasQuery = Boolean(parsed.apiQuery || peopleRole || propCity || propType || listingType || postLocation || postPropType);
 
   const [runPeople, peopleState] = useLazyQuery(SEARCH_USERS_LIGHT, { fetchPolicy: 'network-only', errorPolicy: 'all' });
-  const [runPosts, postsState] = useLazyQuery(SEARCH_POSTS, { fetchPolicy: 'network-only', errorPolicy: 'all' });
+  const [runPosts, postsState] = useLazyQuery(SEARCH_POSTS_LIGHT, { fetchPolicy: 'network-only', errorPolicy: 'all' });
   const [runProps, propsState] = useLazyQuery(PUBLIC_PROPERTIES, { fetchPolicy: 'network-only', errorPolicy: 'all' });
 
   const runSearch = useCallback(
@@ -120,8 +120,8 @@ const SearchPage: React.FC = () => {
       if (needPeople && (apiQ || peopleRole || peopleLocation)) {
         runPeople({
           variables: {
-            // Backend does substring ILIKE matching; don't gate on role here
             search: apiQ || peopleLocation || '',
+            role: peopleRole || null,
             page: 1,
             limit: tab === 'all' ? 8 : 40,
           },
@@ -545,16 +545,12 @@ const SearchPage: React.FC = () => {
         position="sticky"
         elevation={0}
         sx={{
-          ...MATTE_SURFACE,
+          ...MATTE_HEADER,
           borderRadius: 0,
-          borderLeft: 'none',
-          borderRight: 'none',
-          borderTop: 'none',
-          color: '#16302A',
         }}
       >
-        <Toolbar sx={{ gap: 1, maxWidth: 920, width: '100%', mx: 'auto', px: { xs: 1, sm: 2 } }}>
-          <IconButton onClick={() => navigate('/home')} sx={{ color: '#16302A' }} aria-label="Back">
+        <Toolbar sx={{ gap: 1, maxWidth: 920, width: '100%', mx: 'auto', px: { xs: 1, sm: 2 }, bgcolor: 'transparent' }}>
+          <IconButton onClick={() => navigate('/home')} sx={{ color: '#EBE6D4' }} aria-label="Back">
             <ArrowBackIcon />
           </IconButton>
           {!isMobile && <ZpcLogoMark size={40} showTagline={false} animateStroke={false} />}
@@ -564,14 +560,14 @@ const SearchPage: React.FC = () => {
               display: 'flex',
               alignItems: 'center',
               gap: 1,
-              bgcolor: 'rgba(22,48,42,0.06)',
+              bgcolor: 'rgba(235,230,212,0.12)',
               px: 1.5,
               py: 0.65,
               borderRadius: 999,
-              border: '1px solid rgba(22,48,42,0.12)',
+              border: '1px solid rgba(235,230,212,0.28)',
             }}
           >
-            <SearchIcon sx={{ color: '#5C675F', fontSize: 20 }} />
+            <SearchIcon sx={{ color: 'rgba(235,230,212,0.75)', fontSize: 20 }} />
             <InputBase
               fullWidth
               value={draft}
@@ -580,7 +576,12 @@ const SearchPage: React.FC = () => {
                 if (e.key === 'Enter') commitSearch();
               }}
               placeholder='Search people, properties, posts — try "Hyderabad" OR builder'
-              sx={{ fontSize: 14.5, color: '#16302A', ...interFont }}
+              sx={{
+                fontSize: 14.5,
+                color: '#EBE6D4',
+                ...interFont,
+                '& input::placeholder': { color: 'rgba(235,230,212,0.55)', opacity: 1 },
+              }}
             />
             {draft && (
               <IconButton
@@ -589,6 +590,7 @@ const SearchPage: React.FC = () => {
                   setDraft('');
                   commitSearch('');
                 }}
+                sx={{ color: '#EBE6D4' }}
               >
                 <CloseIcon fontSize="small" />
               </IconButton>
@@ -600,11 +602,11 @@ const SearchPage: React.FC = () => {
             sx={{
               textTransform: 'none',
               fontWeight: 700,
-              bgcolor: '#16302A',
-              color: '#fff',
+              bgcolor: 'rgba(235,230,212,0.92)',
+              color: '#16302A',
               borderRadius: 999,
               px: 2,
-              '&:hover': { bgcolor: '#0A1C18' },
+              '&:hover': { bgcolor: '#EBE6D4' },
             }}
           >
             Search
@@ -619,15 +621,17 @@ const SearchPage: React.FC = () => {
             scrollButtons="auto"
             sx={{
               minHeight: 44,
+              bgcolor: 'transparent',
+              border: 'none',
               '& .MuiTab-root': {
                 textTransform: 'none',
                 fontWeight: 700,
                 minHeight: 44,
-                color: '#5C675F',
+                color: 'rgba(235,230,212,0.7)',
                 ...interFont,
               },
-              '& .Mui-selected': { color: '#16302A !important' },
-              '& .MuiTabs-indicator': { bgcolor: '#16302A', height: 2 },
+              '& .Mui-selected': { color: '#EBE6D4 !important' },
+              '& .MuiTabs-indicator': { bgcolor: '#EBE6D4', height: 2 },
             }}
           >
             <Tab value="all" label="All" />
@@ -770,7 +774,7 @@ const SearchPage: React.FC = () => {
             </Stack>
           </Box>
         ) : (
-          <>
+          <TabEnter tabKey={tabParam}>
             <Typography sx={{ mb: 2, color: '#5C675F', fontSize: 13.5 }}>
               Results for <strong style={{ color: '#16302A' }}>{qParam || 'filters'}</strong>
               {loading ? ' · searching…' : ''}
@@ -814,7 +818,7 @@ const SearchPage: React.FC = () => {
             {tabParam === 'posts' && (
               <Box sx={{ ...MATTE_PANEL, borderRadius: CARD_RADIUS, p: 1.75 }}>{renderPosts()}</Box>
             )}
-          </>
+          </TabEnter>
         )}
 
         <Divider sx={{ my: 3, borderColor: 'rgba(22,48,42,0.08)' }} />

--- a/src/components/SharePostSheet.tsx
+++ b/src/components/SharePostSheet.tsx
@@ -1,0 +1,262 @@
+import React, { useMemo, useState } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import IosShareIcon from '@mui/icons-material/IosShare';
+import TelegramMuiIcon from '@mui/icons-material/Telegram';
+import {
+  Box,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+  Tooltip,
+  Snackbar,
+  Alert,
+} from '@mui/material';
+import {
+  ShareablePost,
+  buildPostShareText,
+  buildPostShareUrl,
+  copyTextToClipboard,
+  gmailShareUrl,
+  telegramShareUrl,
+  whatsappShareUrl,
+} from '../utils/sharePost';
+import { ZPC_COLORS, ZPC_FONTS } from '../theme/zpcTheme';
+
+export type SharePostSheetProps = {
+  open: boolean;
+  post: ShareablePost | null;
+  onClose: () => void;
+};
+
+const WhatsAppIcon: React.FC = () => (
+  <Box
+    component="svg"
+    viewBox="0 0 24 24"
+    sx={{ width: 26, height: 26, display: 'block' }}
+    aria-hidden
+  >
+    <path
+      fill="#fff"
+      d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.435 9.884-9.85 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"
+    />
+  </Box>
+);
+
+const TelegramIcon: React.FC = () => (
+  <TelegramMuiIcon sx={{ fontSize: 28, color: '#fff', display: 'block' }} />
+);
+
+const GmailIcon: React.FC = () => (
+  <Box
+    component="svg"
+    viewBox="0 0 24 24"
+    sx={{ width: 26, height: 26, display: 'block' }}
+    aria-hidden
+  >
+    <path
+      fill="#EA4335"
+      d="M24 5.457v13.909c0 .904-.732 1.636-1.636 1.636h-3.819V11.73L12 16.64l-6.545-4.91v9.273H1.636A1.636 1.636 0 0 1 0 19.366V5.457c0-2.023 2.309-3.178 3.927-1.964L5.455 4.64 12 9.548l6.545-4.91 1.528-1.145C21.69 2.28 24 3.434 24 5.457z"
+    />
+  </Box>
+);
+
+type ShareActionProps = {
+  label: string;
+  bg: string;
+  onClick: () => void;
+  children: React.ReactNode;
+};
+
+const ShareAction: React.FC<ShareActionProps> = ({ label, bg, onClick, children }) => (
+  <Tooltip title={label}>
+    <Box
+      component="button"
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      sx={{
+        appearance: 'none',
+        border: 'none',
+        p: 0,
+        m: 0,
+        width: 52,
+        height: 52,
+        borderRadius: '50%',
+        bgcolor: bg,
+        color: '#fff',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'pointer',
+        boxShadow: '0 2px 10px rgba(10,18,16,0.12)',
+        transition: 'transform 0.15s ease, box-shadow 0.15s ease',
+        '&:hover': {
+          transform: 'translateY(-2px)',
+          boxShadow: '0 6px 16px rgba(10,18,16,0.16)',
+        },
+        '&:focus-visible': {
+          outline: `2px solid ${ZPC_COLORS.accent}`,
+          outlineOffset: 2,
+        },
+      }}
+    >
+      {children}
+    </Box>
+  </Tooltip>
+);
+
+const SharePostSheet: React.FC<SharePostSheetProps> = ({ open, post, onClose }) => {
+  const [toast, setToast] = useState<string | null>(null);
+  const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+
+  const { url, text, subject } = useMemo(() => {
+    if (!post) return { url: '', text: '', subject: 'ZPC post' };
+    const shareUrl = buildPostShareUrl(post.id);
+    const shareText = buildPostShareText(post, shareUrl);
+    const shareSubject = (post.title || '').trim() || 'Post on ZPC';
+    return { url: shareUrl, text: shareText, subject: shareSubject };
+  }, [post]);
+
+  const openExternal = (href: string) => {
+    window.open(href, '_blank', 'noopener,noreferrer');
+    onClose();
+  };
+
+  const handleCopy = async () => {
+    const ok = await copyTextToClipboard(url || text);
+    setToast(ok ? 'Link copied' : 'Could not copy link');
+    if (ok) onClose();
+  };
+
+  const handleNativeShare = async () => {
+    if (!canNativeShare || !post) return;
+    try {
+      await navigator.share({
+        title: subject,
+        text: text.replace(url, '').trim(),
+        url,
+      });
+      onClose();
+    } catch (err: any) {
+      if (err?.name !== 'AbortError') {
+        setToast('Could not open share menu');
+      }
+    }
+  };
+
+  return (
+    <>
+      <Dialog
+        open={open && !!post}
+        onClose={onClose}
+        fullWidth
+        maxWidth="xs"
+        PaperProps={{
+          sx: {
+            borderRadius: 3,
+            bgcolor: ZPC_COLORS.surface,
+            border: `1px solid ${ZPC_COLORS.border}`,
+          },
+        }}
+      >
+        <DialogTitle
+          sx={{
+            fontFamily: ZPC_FONTS.display,
+            fontWeight: 600,
+            color: ZPC_COLORS.text,
+            pr: 6,
+            pb: 0.5,
+          }}
+        >
+          Share post
+          <IconButton
+            aria-label="Close"
+            onClick={onClose}
+            sx={{ position: 'absolute', right: 8, top: 8, color: ZPC_COLORS.textMuted }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent sx={{ pt: 1.5, pb: 2.5 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexWrap: 'wrap',
+              gap: 1.75,
+              px: 0.5,
+            }}
+          >
+            <ShareAction
+              label="WhatsApp"
+              bg="#25D366"
+              onClick={() => openExternal(whatsappShareUrl(text))}
+            >
+              <WhatsAppIcon />
+            </ShareAction>
+            <ShareAction
+              label="Telegram"
+              bg="#229ED9"
+              onClick={() => openExternal(telegramShareUrl(url, subject))}
+            >
+              <TelegramIcon />
+            </ShareAction>
+            <Tooltip title="Gmail">
+              <Box
+                component="button"
+                type="button"
+                aria-label="Gmail"
+                onClick={() => openExternal(gmailShareUrl(subject, text))}
+                sx={{
+                  appearance: 'none',
+                  border: '1px solid rgba(0,0,0,0.12)',
+                  p: 0,
+                  m: 0,
+                  width: 52,
+                  height: 52,
+                  borderRadius: '50%',
+                  bgcolor: '#fff',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                  boxShadow: '0 2px 10px rgba(10,18,16,0.12)',
+                  transition: 'transform 0.15s ease, box-shadow 0.15s ease',
+                  '&:hover': {
+                    transform: 'translateY(-2px)',
+                    boxShadow: '0 6px 16px rgba(10,18,16,0.16)',
+                  },
+                }}
+              >
+                <GmailIcon />
+              </Box>
+            </Tooltip>
+            <ShareAction label="Copy link" bg={ZPC_COLORS.primary} onClick={handleCopy}>
+              <ContentCopyIcon sx={{ fontSize: 22, color: ZPC_COLORS.primaryContrast }} />
+            </ShareAction>
+            {canNativeShare && (
+              <ShareAction label="More…" bg={ZPC_COLORS.accent} onClick={handleNativeShare}>
+                <IosShareIcon sx={{ fontSize: 22, color: ZPC_COLORS.accentContrast }} />
+              </ShareAction>
+            )}
+          </Box>
+        </DialogContent>
+      </Dialog>
+      <Snackbar
+        open={!!toast}
+        autoHideDuration={2500}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="info" onClose={() => setToast(null)} sx={{ width: '100%' }}>
+          {toast}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default SharePostSheet;

--- a/src/components/SocialAuthIconsRow.tsx
+++ b/src/components/SocialAuthIconsRow.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Box, IconButton, Tooltip } from '@mui/material';
+import PhoneIphoneIcon from '@mui/icons-material/PhoneIphone';
+import GoogleSignInButton from './GoogleSignInButton';
+import FacebookSignInButton from './FacebookSignInButton';
+
+type SocialAuthIconsRowProps = {
+  disabled?: boolean;
+  onGoogleCredential?: (credential: string) => void;
+  onFacebookAccessToken?: (accessToken: string) => void;
+  onMobileSignIn?: () => void;
+  /** Atmosphere (cream on dark) vs default light styling for the mobile icon. */
+  tone?: 'dark' | 'light';
+};
+
+/**
+ * One-line social auth: Google · Facebook · Mobile as circular icons.
+ */
+const SocialAuthIconsRow: React.FC<SocialAuthIconsRowProps> = ({
+  disabled = false,
+  onGoogleCredential,
+  onFacebookAccessToken,
+  onMobileSignIn,
+  tone = 'dark',
+}) => {
+  if (!onGoogleCredential && !onFacebookAccessToken && !onMobileSignIn) return null;
+
+  const mobileSx =
+    tone === 'dark'
+      ? {
+          width: 48,
+          height: 48,
+          color: '#EBE6D4',
+          bgcolor: 'rgba(235,230,212,0.12)',
+          border: '1px solid rgba(235,230,212,0.35)',
+          '&:hover': { bgcolor: 'rgba(235,230,212,0.2)' },
+          '&.Mui-disabled': { color: '#EBE6D4', opacity: 0.55 },
+        }
+      : {
+          width: 48,
+          height: 48,
+          color: '#16302A',
+          bgcolor: 'rgba(235,230,212,0.65)',
+          border: '1px solid rgba(22,48,42,0.2)',
+          '&:hover': { bgcolor: 'rgba(235,230,212,0.9)' },
+          '&.Mui-disabled': { color: '#16302A', opacity: 0.55 },
+        };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 1.75,
+        width: '100%',
+        py: 0.25,
+      }}
+    >
+      {onGoogleCredential && (
+        <GoogleSignInButton
+          variant="icon"
+          disabled={disabled}
+          onCredential={onGoogleCredential}
+        />
+      )}
+      {onFacebookAccessToken && (
+        <FacebookSignInButton
+          variant="icon"
+          disabled={disabled}
+          onAccessToken={onFacebookAccessToken}
+        />
+      )}
+      {onMobileSignIn && (
+        <Tooltip title="Continue with mobile number">
+          <span>
+            <IconButton
+              disabled={disabled}
+              onClick={onMobileSignIn}
+              aria-label="Continue with mobile number"
+              sx={mobileSx}
+            >
+              <PhoneIphoneIcon sx={{ fontSize: 24 }} />
+            </IconButton>
+          </span>
+        </Tooltip>
+      )}
+    </Box>
+  );
+};
+
+export default SocialAuthIconsRow;

--- a/src/components/admin/AdminBackground.tsx
+++ b/src/components/admin/AdminBackground.tsx
@@ -43,16 +43,16 @@ const AdminBackground: React.FC = () => {
     const draw = () => {
       ctx.clearRect(0, 0, w, h);
 
-      // Atmosphere wash — sage green like Admin
+      // Atmosphere wash — soft mint (#B2DFDB)
       const g = ctx.createLinearGradient(0, 0, w, h);
-      g.addColorStop(0, '#5F8670');
-      g.addColorStop(0.45, '#8FA998');
-      g.addColorStop(1, '#CBD2C4');
+      g.addColorStop(0, '#80CBC4');
+      g.addColorStop(0.48, '#B2DFDB');
+      g.addColorStop(1, '#E0F2F1');
       ctx.fillStyle = g;
       ctx.fillRect(0, 0, w, h);
 
       const radial = ctx.createRadialGradient(w * 0.3, h * 0.2, 0, w * 0.3, h * 0.2, w * 0.55);
-      radial.addColorStop(0, 'rgba(235,230,212,0.45)');
+      radial.addColorStop(0, 'rgba(235,230,212,0.4)');
       radial.addColorStop(1, 'transparent');
       ctx.fillStyle = radial;
       ctx.fillRect(0, 0, w, h);

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -3,53 +3,84 @@ import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
   Alert,
-  AppBar,
   Avatar,
+  Badge,
   Box,
   Button,
   Chip,
   CircularProgress,
   Divider,
+  Drawer,
   IconButton,
   InputBase,
   MenuItem,
   Select,
-  Tab,
-  Tabs,
   ToggleButton,
   ToggleButtonGroup,
-  Toolbar,
+  Tooltip,
   Typography,
+  useMediaQuery,
 } from '@mui/material';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import { ZpcLogoMark } from '../brand/ZpcLogo';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import LogoutIcon from '@mui/icons-material/Logout';
 import HomeIcon from '@mui/icons-material/Home';
 import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
 import HomeWorkIcon from '@mui/icons-material/HomeWork';
 import DynamicFeedIcon from '@mui/icons-material/DynamicFeed';
+import TabEnter from '../motion/TabEnter';
 import SearchIcon from '@mui/icons-material/Search';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import GridViewIcon from '@mui/icons-material/GridView';
+import MenuIcon from '@mui/icons-material/Menu';
+import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import AddIcon from '@mui/icons-material/Add';
+import DashboardOutlinedIcon from '@mui/icons-material/DashboardOutlined';
+import FlagOutlinedIcon from '@mui/icons-material/FlagOutlined';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useAuth } from '../../contexts/AuthContext';
 import {
+  ADMIN_APPROVE_PROPERTY,
   ADMIN_DELETE_POST,
   ADMIN_DELETE_PROPERTY,
+  ADMIN_PENDING_PROPERTIES,
   ADMIN_POSTS,
   ADMIN_PROPERTIES,
+  ADMIN_REJECT_PROPERTY,
+  ADMIN_REPORTS,
+  ADMIN_REPORT_STATS,
+  ADMIN_UPDATE_REPORT_STATUS,
   ADMIN_UPDATE_USER_ROLE,
   ADMIN_USERS,
 } from '../../graphql/admin';
-import AdminBackground from './AdminBackground';
 import { formatDateTime, isRecentlyActive } from '../../utils/datetime';
-import { MATTE_HEADER } from '../../theme/surfaces';
 
-type TabId = 'overview' | 'users' | 'properties' | 'posts';
+type TabId = 'overview' | 'users' | 'posts' | 'properties' | 'reports' | 'approvals';
 type LayoutMode = 'list' | 'grid';
 
-const ACCENT = '#16302A';
+const SIDEBAR_WIDTH = 248;
+const SIDEBAR_BG = '#00796B';
+const ACTIVE_NAV_BG = '#B2DFDB';
+const ACTIVE_NAV_TEXT = '#004D40';
+const MAIN_BG = '#F8FAFC';
+const FONT = "'DM Sans', 'Source Sans 3', system-ui, sans-serif";
 
 const ASSIGNABLE_ROLES = ['admin', 'agent', 'builder', 'general_user'] as const;
+
+const PENDING_PROPERTY_STATUSES = ['PENDING', 'PENDING_VERIFICATION', 'UNDER_REVIEW', 'DRAFT'];
+
+const PAGE_TITLES: Record<TabId, string> = {
+  overview: 'Analytics Overview',
+  users: 'Users',
+  posts: 'Posts',
+  properties: 'Properties',
+  reports: 'Reported Posts',
+  approvals: 'Approvals',
+};
 
 /** Account enabled flag (handles camelCase / lowercase GraphQL). */
 function accountIsActive(u: any): boolean {
@@ -63,26 +94,30 @@ function isLiveOnline(u: any, withinMinutes = 30): boolean {
   return isRecentlyActive(u?.lastLoginAt || u?.last_login_at, withinMinutes);
 }
 
-const listRowHoverSx = {
-  transition: 'background-color 0.22s ease, box-shadow 0.22s ease, transform 0.22s ease',
-  '&:hover': {
-    bgcolor: 'rgba(30,58,72,0.06)',
-    boxShadow: 'inset 3px 0 0 #16302A',
-    transform: 'translateX(2px)',
-  },
-};
+function isPendingProperty(p: any): boolean {
+  const s = String(p?.status || '').toUpperCase();
+  const v = String(p?.verificationStatus || '').toUpperCase();
+  return PENDING_PROPERTY_STATUSES.includes(s) || PENDING_PROPERTY_STATUSES.includes(v);
+}
 
-const gridCardHoverSx = {
-  transition: 'transform 0.25s cubic-bezier(0.22,1,0.36,1), box-shadow 0.25s ease, border-color 0.25s ease',
-  border: '1px solid rgba(22,48,42,0.18)',
-  bgcolor: 'rgba(235,230,212,0.72)',
-  borderRadius: '14px',
-  '&:hover': {
-    transform: 'translateY(-4px) scale(1.015)',
-    boxShadow: '0 14px 32px rgba(30,58,72,0.14)',
-    borderColor: 'rgba(30,58,72,0.28)',
-  },
-};
+function propId(p: any): string {
+  return String(p?.id || p?.propertyId || '');
+}
+
+function propOwnerId(p: any): string {
+  return String(p?.createdBy || p?.userId || '');
+}
+
+function toUiRole(role?: string | null): string {
+  const r = (role || '').toLowerCase();
+  if (r === 'user' || r === 'general' || r === 'general_user') return 'general_user';
+  return r;
+}
+
+function toApiRole(role: string): string {
+  if (role === 'general_user') return 'USER';
+  return role.toUpperCase();
+}
 
 function fmtDate(value?: string | number | null, loc?: { latitude?: number | null; longitude?: number | null }) {
   return formatDateTime(value, {
@@ -97,77 +132,79 @@ function fmtMoney(n?: number | null) {
   return `₹${Number(n).toLocaleString('en-IN')}`;
 }
 
+function userDisplayName(u: any): string {
+  if (!u) return 'Unknown user';
+  const name = `${u.firstName || ''} ${u.lastName || ''}`.trim();
+  return name || u.email || `User #${u.id}`;
+}
+
+const whiteCardSx = {
+  bgcolor: '#FFFFFF',
+  borderRadius: '12px',
+  border: '1px solid #E2E8F0',
+  boxShadow: '0 1px 3px rgba(15, 23, 42, 0.06)',
+};
+
+const listRowHoverSx = {
+  transition: 'background-color 0.18s ease',
+  '&:hover': { bgcolor: '#F8FAFC' },
+};
+
 const KpiCard: React.FC<{
   label: string;
   value: string | number;
   hint?: string;
   icon: React.ReactNode;
-  accent?: string;
-}> = ({ label, value, hint, icon, accent = ACCENT }) => (
+  tileBg: string;
+  tileColor: string;
+}> = ({ label, value, hint, icon, tileBg, tileColor }) => (
   <Box
     sx={{
-      p: 2,
-      borderRadius: '16px',
-      bgcolor: 'rgba(255,252,248,0.78)',
-      border: '1px solid rgba(22,48,42,0.16)',
-      boxShadow: '0 10px 28px rgba(60,45,30,0.08)',
-      backdropFilter: 'blur(10px)',
-      minHeight: 118,
+      ...whiteCardSx,
+      p: 2.5,
+      minHeight: 120,
       display: 'flex',
       flexDirection: 'column',
-      gap: 1,
+      gap: 1.25,
+      flex: '1 1 180px',
     }}
   >
-    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-      <Typography
-        sx={{
-          fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif',
-          fontSize: 12,
-          fontWeight: 800,
-          letterSpacing: '0.06em',
-          textTransform: 'uppercase',
-          color: '#3A4540',
-        }}
-      >
-        {label}
-      </Typography>
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 1 }}>
+      <Typography sx={{ fontSize: 13, fontWeight: 600, color: '#64748B', fontFamily: FONT }}>{label}</Typography>
       <Box
         sx={{
-          width: 36,
-          height: 36,
-          borderRadius: '12px',
-          bgcolor: accent,
-          color: '#EBE6D4',
+          width: 40,
+          height: 40,
+          borderRadius: '10px',
+          bgcolor: tileBg,
+          color: tileColor,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
+          flexShrink: 0,
         }}
       >
         {icon}
       </Box>
     </Box>
-    <Typography
-      sx={{
-        fontFamily: '"Libre Caslon Text", Georgia, serif',
-        fontWeight: 600,
-        fontSize: '2rem',
-        color: '#0A1210',
-        lineHeight: 1,
-      }}
-    >
+    <Typography sx={{ fontWeight: 700, fontSize: '1.75rem', color: '#0F172A', lineHeight: 1, fontFamily: FONT }}>
       {value}
     </Typography>
     {hint && (
-      <Typography sx={{ fontSize: 12, fontWeight: 600, color: '#3A4540' }}>{hint}</Typography>
+      <Typography sx={{ fontSize: 12, fontWeight: 500, color: '#64748B', fontFamily: FONT }}>{hint}</Typography>
     )}
   </Box>
 );
 
 const AdminDashboard: React.FC = () => {
   const navigate = useNavigate();
+  const isMobile = useMediaQuery('(max-width:900px)');
   const { user, clearAuth } = useAuth();
+
   const [tab, setTab] = useState<TabId>('overview');
   const [layoutMode, setLayoutMode] = useState<LayoutMode>('list');
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [headerSearch, setHeaderSearch] = useState('');
   const [userSearch, setUserSearch] = useState('');
   const [propertySearch, setPropertySearch] = useState('');
   const [roleFilter, setRoleFilter] = useState('all');
@@ -191,8 +228,19 @@ const AdminDashboard: React.FC = () => {
     refetch: refetchProps,
     error: propsError,
   } = useQuery(ADMIN_PROPERTIES, {
-    variables: { query: '' },
+    variables: { page: 1, limit: 200 },
     fetchPolicy: 'network-only',
+  });
+
+  const {
+    data: pendingPropsData,
+    loading: pendingPropsLoading,
+    refetch: refetchPendingProps,
+    error: pendingPropsError,
+  } = useQuery(ADMIN_PENDING_PROPERTIES, {
+    variables: { page: 1, limit: 200 },
+    fetchPolicy: 'network-only',
+    errorPolicy: 'all',
   });
 
   const {
@@ -201,53 +249,106 @@ const AdminDashboard: React.FC = () => {
     refetch: refetchPosts,
     error: postsError,
   } = useQuery(ADMIN_POSTS, {
-    variables: { page: 1, limit: 100 },
+    variables: { page: 1, limit: 200 },
     fetchPolicy: 'network-only',
+  });
+
+  const {
+    data: reportsData,
+    loading: reportsLoading,
+    refetch: refetchReports,
+    error: reportsError,
+  } = useQuery(ADMIN_REPORTS, {
+    variables: { status: 'PENDING', page: 1, limit: 100 },
+    fetchPolicy: 'network-only',
+    errorPolicy: 'all',
+  });
+
+  const { data: reportStatsData, refetch: refetchReportStats } = useQuery(ADMIN_REPORT_STATS, {
+    fetchPolicy: 'network-only',
+    errorPolicy: 'all',
   });
 
   const [deletePost, { loading: deletingPost }] = useMutation(ADMIN_DELETE_POST);
   const [deleteProperty, { loading: deletingProperty }] = useMutation(ADMIN_DELETE_PROPERTY);
   const [updateUserRole, { loading: updatingRole }] = useMutation(ADMIN_UPDATE_USER_ROLE);
+  const [approveProperty, { loading: approvingProperty }] = useMutation(ADMIN_APPROVE_PROPERTY);
+  const [rejectProperty, { loading: rejectingProperty }] = useMutation(ADMIN_REJECT_PROPERTY);
+  const [updateReportStatus, { loading: updatingReport }] = useMutation(ADMIN_UPDATE_REPORT_STATUS);
 
   const users = usersData?.users || [];
-  const properties = propsData?.searchProperties || [];
+  const publicProperties = propsData?.publicProperties?.properties || [];
+  const queueProperties = pendingPropsData?.pendingProperties?.properties || [];
+  const properties = useMemo(() => {
+    const map = new Map<string, any>();
+    [...publicProperties, ...queueProperties].forEach((p: any) => {
+      if (p?.id) map.set(String(p.id), p);
+    });
+    return Array.from(map.values());
+  }, [publicProperties, queueProperties]);
   const posts = postsData?.searchPosts || [];
-  const loading = usersLoading || propsLoading || postsLoading;
+  const reports = reportsData?.reports?.reports || [];
+  const pendingReportCount =
+    reportStatsData?.reportStats?.pendingCount ?? (reportsError ? 0 : reports.length);
+
+  const loading = usersLoading || propsLoading || postsLoading || pendingPropsLoading;
+
+  const userById = useMemo(() => {
+    const map = new Map<string, any>();
+    users.forEach((u: any) => map.set(String(u.id), u));
+    return map;
+  }, [users]);
+
+  const pendingProperties = useMemo(() => {
+    if (queueProperties.length) return queueProperties;
+    return properties.filter(isPendingProperty);
+  }, [queueProperties, properties]);
 
   const stats = useMemo(() => {
     const activeUsers = users.filter((u: any) => accountIsActive(u)).length;
-    const inactiveUsers = users.length - activeUsers;
     const liveUsers = users.filter((u: any) => accountIsActive(u) && isLiveOnline(u)).length;
-    const activeProps = properties.filter(
-      (p: any) => p.isActive !== false && String(p.status || '').toUpperCase() === 'ACTIVE'
-    ).length;
     const byRole: Record<string, number> = {};
     users.forEach((u: any) => {
       const r = (u.role || 'unknown').toLowerCase();
       byRole[r] = (byRole[r] || 0) + 1;
     });
-    const byPropType: Record<string, number> = {};
-    properties.forEach((p: any) => {
-      const t = p.propertyType || 'OTHER';
-      byPropType[t] = (byPropType[t] || 0) + 1;
-    });
     return {
       totalUsers: users.length,
       activeUsers,
-      inactiveUsers,
       liveUsers,
       totalProperties: properties.length,
-      activeProps,
       totalPosts: posts.length,
-      totalLikes: posts.reduce((s: number, p: any) => s + (p.likeCount || 0), 0),
-      totalComments: posts.reduce((s: number, p: any) => s + (p.commentCount || 0), 0),
+      reportedPosts: pendingReportCount,
       byRole,
-      byPropType,
     };
-  }, [users, properties, posts]);
+  }, [users, properties, posts, pendingReportCount]);
+
+  const postsByDay = useMemo(() => {
+    const days: { label: string; count: number }[] = [];
+    for (let i = 13; i >= 0; i--) {
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+      d.setDate(d.getDate() - i);
+      const key = d.toISOString().slice(0, 10);
+      const label = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      const count = posts.filter((p: any) => {
+        if (!p.createdAt) return false;
+        const created = new Date(p.createdAt);
+        created.setHours(0, 0, 0, 0);
+        return created.toISOString().slice(0, 10) === key;
+      }).length;
+      days.push({ label, count });
+    }
+    return days;
+  }, [posts]);
+
+  const maxPostsDay = Math.max(1, ...postsByDay.map((d) => d.count));
+
+  const effectiveUserSearch = tab === 'users' ? headerSearch || userSearch : userSearch;
+  const effectivePropertySearch = tab === 'properties' ? headerSearch || propertySearch : propertySearch;
 
   const filteredUsers = useMemo(() => {
-    const q = userSearch.trim().toLowerCase();
+    const q = effectiveUserSearch.trim().toLowerCase();
     return users.filter((u: any) => {
       if (roleFilter !== 'all' && (u.role || '').toLowerCase() !== roleFilter) return false;
       if (userStatusFilter === 'active' && !accountIsActive(u)) return false;
@@ -258,28 +359,52 @@ const AdminDashboard: React.FC = () => {
       const hay = `${u.firstName} ${u.lastName} ${u.email} ${u.phone || ''} ${u.role || ''}`.toLowerCase();
       return hay.includes(q);
     });
-  }, [users, userSearch, roleFilter, userStatusFilter]);
+  }, [users, effectiveUserSearch, roleFilter, userStatusFilter]);
 
   const filteredProperties = useMemo(() => {
-    const q = propertySearch.trim().toLowerCase();
+    const q = effectivePropertySearch.trim().toLowerCase();
     return properties.filter((p: any) => {
       if (statusFilter !== 'all' && String(p.status || '').toUpperCase() !== statusFilter) return false;
       if (!q) return true;
       const hay = `${p.title} ${p.location || ''} ${p.city || ''} ${p.propertyType || ''}`.toLowerCase();
       return hay.includes(q);
     });
-  }, [properties, propertySearch, statusFilter]);
+  }, [properties, effectivePropertySearch, statusFilter]);
+
+  const roleOptions = useMemo(() => {
+    const set = new Set<string>();
+    users.forEach((u: any) => set.add((u.role || 'unknown').toLowerCase()));
+    return Array.from(set).sort();
+  }, [users]);
+
+  const adminName = useMemo(() => {
+    const name = `${user?.firstName || ''} ${user?.lastName || ''}`.trim();
+    return name || 'Admin';
+  }, [user]);
+
+  const navigateTab = (next: TabId) => {
+    setTab(next);
+    setSidebarOpen(false);
+    setHeaderSearch('');
+  };
 
   const refreshAll = async () => {
     setActionMsg(null);
-    await Promise.all([refetchUsers(), refetchProps(), refetchPosts()]);
-    setActionMsg({ type: 'success', text: 'Dashboard data refreshed from live services.' });
+    await Promise.all([
+      refetchUsers(),
+      refetchProps(),
+      refetchPendingProps(),
+      refetchPosts(),
+      refetchReports().catch(() => undefined),
+      refetchReportStats().catch(() => undefined),
+    ]);
+    setActionMsg({ type: 'success', text: 'Dashboard data refreshed.' });
   };
 
-  const onDeletePost = async (postId: number) => {
+  const onDeletePost = async (postId: number | string) => {
     if (!window.confirm(`Delete post #${postId}? This cannot be undone.`)) return;
     try {
-      const { data } = await deletePost({ variables: { postId } });
+      const { data } = await deletePost({ variables: { postId: String(postId) } });
       if (data?.deletePost?.success) {
         setActionMsg({ type: 'success', text: `Post #${postId} deleted.` });
         refetchPosts();
@@ -295,14 +420,70 @@ const AdminDashboard: React.FC = () => {
     if (!window.confirm(`Delete property ${propertyId}? This cannot be undone.`)) return;
     try {
       const { data } = await deleteProperty({ variables: { propertyId: String(propertyId) } });
-      if (data?.deleteProperty) {
+      if (data?.deleteProperty?.success) {
         setActionMsg({ type: 'success', text: `Property ${propertyId} deleted.` });
-        refetchProps();
+        await Promise.all([refetchProps(), refetchPendingProps()]);
       } else {
-        setActionMsg({ type: 'error', text: 'Property delete failed.' });
+        setActionMsg({ type: 'error', text: data?.deleteProperty?.message || 'Property delete failed.' });
       }
     } catch (e: any) {
       setActionMsg({ type: 'error', text: e.message || 'Property delete failed.' });
+    }
+  };
+
+  const onApproveProperty = async (propertyId: string | number) => {
+    try {
+      const { data } = await approveProperty({ variables: { propertyId: String(propertyId) } });
+      if (data?.approveProperty?.id) {
+        setActionMsg({ type: 'success', text: `Property "${data.approveProperty.title}" approved.` });
+        await Promise.all([refetchProps(), refetchPendingProps()]);
+      } else {
+        setActionMsg({ type: 'error', text: 'Approve failed.' });
+      }
+    } catch (e: any) {
+      setActionMsg({ type: 'error', text: e.message || 'Approve failed.' });
+    }
+  };
+
+  const onRejectProperty = async (propertyId: string | number) => {
+    const reason = window.prompt('Rejection reason (optional):', 'Rejected by admin') || 'Rejected by admin';
+    try {
+      const { data } = await rejectProperty({
+        variables: { propertyId: String(propertyId), reason },
+      });
+      if (data?.rejectProperty?.id) {
+        setActionMsg({ type: 'success', text: `Property "${data.rejectProperty.title}" rejected.` });
+        await Promise.all([refetchProps(), refetchPendingProps()]);
+      } else {
+        setActionMsg({ type: 'error', text: 'Reject failed.' });
+      }
+    } catch (e: any) {
+      setActionMsg({ type: 'error', text: e.message || 'Reject failed.' });
+    }
+  };
+
+  const onUpdateReport = async (reportId: string, status: 'RESOLVED' | 'REJECTED') => {
+    const label = status === 'RESOLVED' ? 'resolve' : 'dismiss';
+    if (!window.confirm(`${label.charAt(0).toUpperCase() + label.slice(1)} report ${reportId}?`)) return;
+    try {
+      const { data } = await updateReportStatus({
+        variables: {
+          reportId: String(reportId),
+          status,
+          reviewedBy: user?.email || String(user?.id || 'admin'),
+          actionTaken: status === 'RESOLVED' ? 'RESOLVED' : 'DISMISSED',
+          actionNote: status === 'RESOLVED' ? 'Resolved by admin' : 'Dismissed by admin',
+        },
+      });
+      if (data?.updateReportStatus?.success) {
+        setActionMsg({ type: 'success', text: `Report ${reportId} ${status === 'RESOLVED' ? 'resolved' : 'dismissed'}.` });
+        refetchReports().catch(() => undefined);
+        refetchReportStats().catch(() => undefined);
+      } else {
+        setActionMsg({ type: 'error', text: data?.updateReportStatus?.message || 'Update failed.' });
+      }
+    } catch (e: any) {
+      setActionMsg({ type: 'error', text: e.message || 'Update failed.' });
     }
   };
 
@@ -313,7 +494,7 @@ const AdminDashboard: React.FC = () => {
       setActionMsg({ type: 'error', text: 'You cannot remove your own admin role.' });
       return;
     }
-    const name = `${targetUser.firstName || ''} ${targetUser.lastName || ''}`.trim() || targetUser.email;
+    const name = userDisplayName(targetUser);
     if (
       !window.confirm(
         `Change ${name} to role "${nextRole}"? They must log out/in for JWT privileges to refresh.`
@@ -323,7 +504,7 @@ const AdminDashboard: React.FC = () => {
     }
     try {
       const { data } = await updateUserRole({
-        variables: { userId: parseInt(String(targetUser.id), 10), role: nextRole },
+        variables: { userId: String(targetUser.id), role: toApiRole(nextRole) },
       });
       if (data?.updateUserRole?.id) {
         setActionMsg({
@@ -339,872 +520,974 @@ const AdminDashboard: React.FC = () => {
     }
   };
 
-  const roleOptions = useMemo(() => {
-    const set = new Set<string>();
-    users.forEach((u: any) => set.add((u.role || 'unknown').toLowerCase()));
-    return Array.from(set).sort();
-  }, [users]);
+  const handleLogout = () => {
+    clearAuth();
+    navigate('/');
+  };
 
-  return (
-    <Box sx={{ position: 'relative', minHeight: '100vh', color: '#0A1210' }}>
-      <AdminBackground />
-
-      <AppBar
-        position="sticky"
-        elevation={0}
+  const navItem = (id: TabId, label: string, icon: React.ReactNode, badge?: number, badgeColor?: string) => {
+    const active = tab === id;
+    return (
+      <Box
+        key={id}
+        component="button"
+        onClick={() => navigateTab(id)}
         sx={{
-          zIndex: 20,
-          ...MATTE_HEADER,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.25,
+          width: '100%',
+          border: 'none',
+          cursor: 'pointer',
+          textAlign: 'left',
+          px: 1.5,
+          py: 1,
+          mb: 0.5,
+          borderRadius: '8px',
+          bgcolor: active ? ACTIVE_NAV_BG : 'transparent',
+          color: active ? ACTIVE_NAV_TEXT : 'rgba(255, 252, 240, 0.82)',
+          fontFamily: FONT,
+          fontWeight: active ? 700 : 500,
+          fontSize: 14,
+          transition: 'background-color 0.15s ease',
+          '&:hover': { bgcolor: active ? ACTIVE_NAV_BG : 'rgba(255,255,255,0.08)' },
+          '& .nav-icon': { opacity: active ? 1 : 0.75, fontSize: 20 },
         }}
       >
-        <Toolbar
-          sx={{
-            gap: 1,
-            flexWrap: 'wrap',
-            py: 0.5,
-            width: '100%',
-            maxWidth: '100%',
-            mx: 'auto',
-            px: { xs: 2, sm: 3, md: 4, lg: 5 },
-          }}
-        >
-          <Box sx={{ flex: 1, minWidth: 180 }}>
-            <Typography
-              sx={{
-                fontFamily: '"Libre Caslon Text", Georgia, serif',
-                fontWeight: 600,
-                fontSize: '1.35rem',
-                color: '#EBE6D4',
-                lineHeight: 1.1,
-              }}
-            >
-              ZPC Admin
-            </Typography>
-            <Typography sx={{ fontSize: 12, fontWeight: 600, color: 'rgba(235,230,212,0.78)' }}>
-              Platform operations · {user?.email}
-            </Typography>
-          </Box>
-          <IconButton onClick={refreshAll} title="Refresh" sx={{ color: '#EBE6D4' }}>
-            <RefreshIcon />
-          </IconButton>
-          <Button
-            startIcon={<HomeIcon />}
-            onClick={() => navigate('/home')}
-            sx={{ textTransform: 'none', fontWeight: 700, color: '#EBE6D4' }}
-          >
-            App home
-          </Button>
-          <Button
-            startIcon={<LogoutIcon />}
-            onClick={() => {
-              clearAuth();
-              navigate('/');
-            }}
-            sx={{
-              textTransform: 'none',
-              fontWeight: 700,
-              bgcolor: 'rgba(22, 48, 42, 0.72)',
-              color: '#EBE6D4',
-              borderRadius: '10px',
-              px: 1.5,
-              border: '1px solid rgba(235,230,212,0.28)',
-              '&:hover': { bgcolor: 'rgba(15, 34, 28, 0.88)' },
-            }}
-          >
-            Logout
-          </Button>
-        </Toolbar>
-      </AppBar>
-
-      <Box sx={{ position: 'relative', zIndex: 1, width: '100%', maxWidth: '100%', mx: 'auto', px: { xs: 2, sm: 3, md: 4, lg: 5 }, py: 3 }}>
-        {(usersError || propsError || postsError) && (
-          <Alert severity="warning" sx={{ mb: 2, borderRadius: 2 }}>
-            Some admin data failed to load. Showing whatever is available from the live database services.
-          </Alert>
-        )}
-        {actionMsg && (
-          <Alert
-            severity={actionMsg.type}
-            sx={{ mb: 2, borderRadius: 2 }}
-            onClose={() => setActionMsg(null)}
-          >
-            {actionMsg.text}
-          </Alert>
-        )}
-
-        <Box
-          sx={{
-            mb: 2.5,
-            p: 0.5,
-            borderRadius: '999px',
-            bgcolor: 'rgba(235,230,212,0.35)',
-            backdropFilter: 'blur(12px) saturate(1.15)',
-            WebkitBackdropFilter: 'blur(12px) saturate(1.15)',
-            border: '1px solid rgba(22,48,42,0.2)',
-            width: 'fit-content',
-            maxWidth: '100%',
-          }}
-        >
-          <Tabs
-            value={tab}
-            onChange={(_, v) => setTab(v)}
-            variant="scrollable"
-            scrollButtons="auto"
-            sx={{
-              minHeight: 42,
-              '& .MuiTabs-indicator': { display: 'none' },
-              '& .MuiTab-root': {
-                textTransform: 'none',
-                fontWeight: 700,
-                fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif',
-                minHeight: 34,
-                borderRadius: 999,
-                mx: 0.25,
-                color: '#3A4540',
-              },
-              '& .Mui-selected': {
-                color: '#EBE6D4 !important',
-                bgcolor: 'rgba(22,48,42,0.88) !important',
-              },
-            }}
-          >
-            <Tab value="overview" label="Overview" />
-            <Tab value="users" label={`Users (${stats.totalUsers})`} />
-            <Tab value="properties" label={`Properties (${stats.totalProperties})`} />
-            <Tab value="posts" label={`Posts (${stats.totalPosts})`} />
-          </Tabs>
+        <Box className="nav-icon" sx={{ display: 'flex', alignItems: 'center' }}>
+          {icon}
         </Box>
-
-        {loading && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-            <CircularProgress sx={{ color: ACCENT }} />
-          </Box>
-        )}
-
-        {!loading && tab === 'overview' && (
-          <Box>
-            <Box
-              sx={{
-                display: 'grid',
-                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(4, 1fr)' },
-                gap: 1.5,
-                mb: 2.5,
-              }}
-            >
-              <KpiCard
-                label="Users"
-                value={stats.totalUsers}
-                hint={`${stats.liveUsers} live · ${stats.activeUsers} active · ${stats.inactiveUsers} inactive`}
-                icon={<PeopleAltIcon sx={{ fontSize: 20 }} />}
-              />
-              <KpiCard
-                label="Properties"
-                value={stats.totalProperties}
-                hint={`${stats.activeProps} listed active`}
-                icon={<HomeWorkIcon sx={{ fontSize: 20 }} />}
-                accent="#16302A"
-              />
-              <KpiCard
-                label="Posts"
-                value={stats.totalPosts}
-                hint={`${stats.totalLikes} likes · ${stats.totalComments} comments`}
-                icon={<DynamicFeedIcon sx={{ fontSize: 20 }} />}
-                accent="#3A4540"
-              />
-              <KpiCard
-                label="Engagement"
-                value={stats.totalLikes + stats.totalComments}
-                hint="Likes + comments across feed"
-                icon={<DynamicFeedIcon sx={{ fontSize: 20 }} />}
-                accent="#0F221C"
-              />
-            </Box>
-
-            <Box
-              sx={{
-                display: 'grid',
-                gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
-                gap: 1.5,
-              }}
-            >
-              <Box
-                sx={{
-                  p: 2.25,
-                  borderRadius: '16px',
-                  bgcolor: 'rgba(255,252,248,0.8)',
-                  border: '1px solid rgba(22,48,42,0.16)',
-                }}
-              >
-                <Typography sx={{ fontWeight: 800, mb: 1.5, color: '#0A1210' }}>Users by role</Typography>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                  {Object.entries(stats.byRole).map(([role, count]) => (
-                    <Chip
-                      key={role}
-                      label={`${role}: ${count}`}
-                      sx={{
-                        fontWeight: 700,
-                        bgcolor: role === 'admin' ? 'rgba(30,58,72,0.12)' : 'rgba(143,169,152,0.35)',
-                        color: ACCENT,
-                      }}
-                    />
-                  ))}
-                  {Object.keys(stats.byRole).length === 0 && (
-                    <Typography sx={{ color: '#3A4540', fontSize: 13 }}>No users loaded.</Typography>
-                  )}
-                </Box>
-              </Box>
-              <Box
-                sx={{
-                  p: 2.25,
-                  borderRadius: '16px',
-                  bgcolor: 'rgba(255,252,248,0.8)',
-                  border: '1px solid rgba(22,48,42,0.16)',
-                }}
-              >
-                <Typography sx={{ fontWeight: 800, mb: 1.5, color: '#0A1210' }}>Properties by type</Typography>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                  {Object.entries(stats.byPropType).map(([type, count]) => (
-                    <Chip
-                      key={type}
-                      label={`${type}: ${count}`}
-                      sx={{ fontWeight: 700, bgcolor: 'rgba(15,118,110,0.12)', color: '#16302A' }}
-                    />
-                  ))}
-                  {Object.keys(stats.byPropType).length === 0 && (
-                    <Typography sx={{ color: '#3A4540', fontSize: 13 }}>No properties loaded.</Typography>
-                  )}
-                </Box>
-              </Box>
-            </Box>
-
-            <Box
-              sx={{
-                mt: 2,
-                p: 2,
-                borderRadius: '16px',
-                bgcolor: 'rgba(255,252,248,0.8)',
-                border: '1px solid rgba(22,48,42,0.16)',
-              }}
-            >
-              <Typography sx={{ fontWeight: 800, mb: 1, color: '#0A1210' }}>Admin capabilities</Typography>
-              <Typography sx={{ fontSize: 13, color: '#3A4540', lineHeight: 1.55 }}>
-                This console reads live data from user, property, and post services. Use the Users tab to change roles
-                (admin, agent, builder, general_user). Role changes apply on the next login. You can also open app pages
-                or remove abusive posts/listings from the other tabs.
-              </Typography>
-            </Box>
-          </Box>
-        )}
-
-        {!loading && tab === 'users' && (
+        <Box component="span" sx={{ flex: 1 }}>
+          {label}
+        </Box>
+        {badge != null && badge > 0 && (
           <Box
             sx={{
-              borderRadius: '16px',
-              bgcolor: 'rgba(235,230,212,0.82)',
-              border: '1px solid rgba(22,48,42,0.16)',
-              overflow: 'hidden',
+              minWidth: 20,
+              height: 20,
+              px: 0.75,
+              borderRadius: '10px',
+              bgcolor: badgeColor || '#EF4444',
+              color: '#fff',
+              fontSize: 11,
+              fontWeight: 700,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             }}
           >
-            <Box sx={{ p: 1.5, display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+            {badge}
+          </Box>
+        )}
+      </Box>
+    );
+  };
+
+  const sidebarContent = (
+    <Box
+      sx={{
+        width: SIDEBAR_WIDTH,
+        height: '100%',
+        bgcolor: SIDEBAR_BG,
+        color: '#FFFBF0',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: FONT,
+      }}
+    >
+      <Box sx={{ px: 2.5, pt: 2.5, pb: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+          <ZpcLogoMark size={40} showTagline={false} animateStroke={false} ink="light" />
+          <Typography sx={{ fontWeight: 700, fontSize: '1.1rem', color: '#FFFBF0', fontFamily: FONT }}>
+            ZPC stats
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box sx={{ flex: 1, overflowY: 'auto', px: 1.5 }}>
+        <Typography
+          sx={{
+            px: 1.5,
+            mb: 1,
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+            color: 'rgba(255, 252, 240, 0.55)',
+          }}
+        >
+          DASHBOARDS
+        </Typography>
+        {navItem('overview', 'Overview', <DashboardOutlinedIcon />)}
+        {navItem('users', 'Users', <PeopleAltIcon />)}
+        {navItem('posts', 'Posts', <DynamicFeedIcon />)}
+        {navItem('properties', 'Properties', <HomeWorkIcon />)}
+
+        <Typography
+          sx={{
+            px: 1.5,
+            mt: 2.5,
+            mb: 1,
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+            color: 'rgba(255, 252, 240, 0.55)',
+          }}
+        >
+          MODERATION
+        </Typography>
+        {navItem('reports', 'Reported Posts', <FlagOutlinedIcon />, pendingReportCount, '#EF4444')}
+        {navItem('approvals', 'Approvals', <CheckCircleOutlineIcon />, pendingProperties.length, '#F59E0B')}
+      </Box>
+
+      <Divider sx={{ borderColor: 'rgba(255,255,255,0.12)' }} />
+      <Box sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 1.25 }}>
+        <Tooltip title="Logout" placement="top">
+          <Avatar
+            onClick={handleLogout}
+            src={user?.profilePhotoSignedUrl || user?.profilePhoto || undefined}
+            sx={{
+              width: 40,
+              height: 40,
+              bgcolor: ACTIVE_NAV_BG,
+              color: ACTIVE_NAV_TEXT,
+              fontWeight: 700,
+              cursor: 'pointer',
+            }}
+          >
+            {(adminName || user?.email || 'A').charAt(0).toUpperCase()}
+          </Avatar>
+        </Tooltip>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            sx={{
+              fontWeight: 700,
+              fontSize: 13,
+              color: '#FFFBF0',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {adminName}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: 11,
+              color: 'rgba(255, 252, 240, 0.65)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {user?.email}
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+
+  const renderOverview = () => (
+    <Box>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2.5, alignItems: 'center' }}>
+        <Chip
+          label="Last 30 Days"
+          sx={{ fontWeight: 600, bgcolor: '#fff', border: '1px solid #E2E8F0', fontFamily: FONT }}
+        />
+        <Button
+          startIcon={<FilterListIcon />}
+          variant="outlined"
+          size="small"
+          sx={{
+            textTransform: 'none',
+            fontWeight: 600,
+            borderColor: '#E2E8F0',
+            color: '#475569',
+            fontFamily: FONT,
+          }}
+        >
+          Filters
+        </Button>
+      </Box>
+
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2.5 }}>
+        <KpiCard
+          label="Total Users"
+          value={stats.totalUsers}
+          icon={<PeopleAltIcon sx={{ fontSize: 22 }} />}
+          tileBg="#DBEAFE"
+          tileColor="#2563EB"
+        />
+        <KpiCard
+          label="Active Users"
+          value={stats.activeUsers}
+          hint={stats.liveUsers > 0 ? `+${stats.liveUsers} live online` : undefined}
+          icon={<PeopleAltIcon sx={{ fontSize: 22 }} />}
+          tileBg="#DCFCE7"
+          tileColor="#16A34A"
+        />
+        <KpiCard
+          label="Total Posts"
+          value={stats.totalPosts}
+          icon={<DynamicFeedIcon sx={{ fontSize: 22 }} />}
+          tileBg="#F3E8FF"
+          tileColor="#9333EA"
+        />
+        <KpiCard
+          label="Properties Created"
+          value={stats.totalProperties}
+          icon={<HomeWorkIcon sx={{ fontSize: 22 }} />}
+          tileBg="#FFEDD5"
+          tileColor="#EA580C"
+        />
+        <KpiCard
+          label="Reported Posts"
+          value={stats.reportedPosts}
+          icon={<FlagOutlinedIcon sx={{ fontSize: 22 }} />}
+          tileBg="#FEE2E2"
+          tileColor="#DC2626"
+        />
+      </Box>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', lg: '2fr 1fr' },
+          gap: 2,
+          mb: 2.5,
+        }}
+      >
+        <Box sx={{ ...whiteCardSx, p: 2.5 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: 15, color: '#0F172A', mb: 2, fontFamily: FONT }}>
+            Total Posts Created by Day
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1, height: 180, px: 0.5 }}>
+            {postsByDay.map((d) => (
               <Box
+                key={d.label}
                 sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
                   flex: 1,
-                  minWidth: 200,
-                  px: 1.25,
-                  py: 0.75,
-                  borderRadius: '12px',
-                  bgcolor: 'rgba(235,230,212,0.78)',
-                  border: '1px solid rgba(22,48,42,0.18)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  minWidth: 0,
                 }}
               >
-                <SearchIcon sx={{ color: '#A89F84', fontSize: 20 }} />
-                <InputBase
-                  fullWidth
-                  placeholder="Search name, email, phone, role…"
-                  value={userSearch}
-                  onChange={(e) => setUserSearch(e.target.value)}
-                  sx={{ fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif', fontSize: 14 }}
+                <Typography sx={{ fontSize: 10, fontWeight: 600, color: '#64748B' }}>{d.count}</Typography>
+                <Box
+                  sx={{
+                    width: '100%',
+                    maxWidth: 36,
+                    height: `${Math.max(4, (d.count / maxPostsDay) * 140)}px`,
+                    bgcolor: '#00796B',
+                    borderRadius: '4px 4px 0 0',
+                    transition: 'height 0.3s ease',
+                  }}
                 />
+                <Typography
+                  sx={{
+                    fontSize: 9,
+                    fontWeight: 500,
+                    color: '#94A3B8',
+                    textAlign: 'center',
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {d.label}
+                </Typography>
               </Box>
-              <Select
-                size="small"
-                value={roleFilter}
-                onChange={(e) => setRoleFilter(String(e.target.value))}
-                sx={{ minWidth: 140, borderRadius: '10px', bgcolor: 'rgba(235, 230, 212,0.8)' }}
-              >
-                <MenuItem value="all">All roles</MenuItem>
-                {roleOptions.map((r) => (
-                  <MenuItem key={r} value={r}>
-                    {r}
-                  </MenuItem>
-                ))}
-              </Select>
-              <Select
-                size="small"
-                value={userStatusFilter}
-                onChange={(e) => setUserStatusFilter(String(e.target.value))}
-                sx={{ minWidth: 140, borderRadius: '10px', bgcolor: 'rgba(235, 230, 212,0.8)' }}
-              >
-                <MenuItem value="all">All status</MenuItem>
-                <MenuItem value="online">Live online</MenuItem>
-                <MenuItem value="offline">Offline</MenuItem>
-                <MenuItem value="active">Account active</MenuItem>
-                <MenuItem value="inactive">Account inactive</MenuItem>
-              </Select>
-              <ToggleButtonGroup
-                exclusive
-                size="small"
-                value={layoutMode}
-                onChange={(_, v) => v && setLayoutMode(v)}
-                sx={{
-                  bgcolor: 'rgba(235, 230, 212,0.8)',
-                  borderRadius: '10px',
-                  '& .MuiToggleButton-root': { px: 1.1, border: 'none', color: '#3A4540' },
-                  '& .Mui-selected': { bgcolor: 'rgba(30,58,72,0.12) !important', color: `${ACCENT} !important` },
-                }}
-              >
-                <ToggleButton value="list" aria-label="List view">
-                  <ViewListIcon fontSize="small" />
-                </ToggleButton>
-                <ToggleButton value="grid" aria-label="Grid view">
-                  <GridViewIcon fontSize="small" />
-                </ToggleButton>
-              </ToggleButtonGroup>
-            </Box>
-            <Divider />
-            {layoutMode === 'list' ? (
-            <Box sx={{ overflowX: 'auto' }}>
-              <Box
-                component="table"
-                sx={{
-                  width: '100%',
-                  borderCollapse: 'collapse',
-                  '& th, & td': {
-                    textAlign: 'left',
-                    px: 1.5,
-                    py: 1.15,
-                    fontSize: 13,
-                    borderBottom: '1px solid rgba(90,70,50,0.08)',
-                    fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif',
-                  },
-                  '& th': { fontWeight: 800, color: '#3A4540', bgcolor: 'rgba(246,242,235,0.7)' },
-                  '& tbody tr': listRowHoverSx,
-                }}
-              >
-                <thead>
-                  <tr>
-                    <th>ID</th>
-                    <th>User</th>
-                    <th>Role</th>
-                    <th>Live</th>
-                    <th>Account</th>
-                    <th>Joined</th>
-                    <th />
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredUsers.map((u: any) => (
-                    <tr key={u.id}>
-                      <td>{u.id}</td>
-                      <td>
-                        <Typography sx={{ fontWeight: 700, fontSize: 13 }}>
-                          {u.firstName} {u.lastName}
-                        </Typography>
-                        <Typography sx={{ fontSize: 12, color: '#3A4540' }}>{u.email}</Typography>
-                      </td>
-                      <td>
-                        <Select
-                          size="small"
-                          value={
-                            ASSIGNABLE_ROLES.includes((u.role || '').toLowerCase() as any)
-                              ? (u.role || '').toLowerCase()
-                              : 'general_user'
-                          }
-                          disabled={updatingRole}
-                          onChange={(e) => handleRoleChange(u, String(e.target.value))}
-                          sx={{
-                            minWidth: 140,
-                            fontWeight: 700,
-                            fontSize: 12,
-                            borderRadius: '10px',
-                            bgcolor: 'rgba(235, 230, 212,0.9)',
-                          }}
-                        >
-                          {ASSIGNABLE_ROLES.map((r) => (
-                            <MenuItem key={r} value={r}>
-                              {r}
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </td>
-                      <td>
-                        <Chip
-                          size="small"
-                          label={isLiveOnline(u) ? 'Online' : 'Offline'}
-                          color={isLiveOnline(u) ? 'success' : 'default'}
-                          sx={{ fontWeight: 700 }}
-                        />
-                      </td>
-                      <td>
-                        <Chip
-                          size="small"
-                          label={accountIsActive(u) ? 'Active' : 'Inactive'}
-                          color={accountIsActive(u) ? 'success' : 'default'}
-                          variant={accountIsActive(u) ? 'filled' : 'outlined'}
-                          sx={{ fontWeight: 700 }}
-                        />
-                      </td>
-                      <td>{fmtDate(u.createdAt, u)}</td>
-                      <td>
-                        <Button
-                          size="small"
-                          sx={{ textTransform: 'none', fontWeight: 700 }}
-                          onClick={() => navigate('/profile', { state: { userId: u.id } })}
-                        >
-                          Open
-                        </Button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </Box>
-              {filteredUsers.length === 0 && (
-                <Typography sx={{ p: 3, textAlign: 'center', color: '#3A4540' }}>No users match.</Typography>
-              )}
-            </Box>
-            ) : (
-            <Box
-              sx={{
-                p: 1.5,
-                display: 'grid',
-                gap: 1.5,
-                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)', lg: 'repeat(4, 1fr)' },
-              }}
-            >
-              {filteredUsers.map((u: any) => (
-                <Box key={u.id} sx={{ ...gridCardHoverSx, p: 1.75, display: 'flex', flexDirection: 'column', gap: 1.25 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
-                    <Box sx={{ position: 'relative' }}>
-                      <Avatar
-                        src={u.profilePhotoSignedUrl || u.profilePhoto || undefined}
-                        sx={{ width: 44, height: 44, bgcolor: ACCENT, fontWeight: 800 }}
-                      >
-                        {(u.firstName || u.email || '?').charAt(0).toUpperCase()}
-                      </Avatar>
+            ))}
+          </Box>
+        </Box>
+
+        <Box sx={{ ...whiteCardSx, p: 2.5 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: 15, color: '#0F172A', mb: 2, fontFamily: FONT }}>
+            User Demographics
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            {Object.entries(stats.byRole)
+              .sort((a, b) => b[1] - a[1])
+              .map(([role, count]) => {
+                const pct = stats.totalUsers ? (count / stats.totalUsers) * 100 : 0;
+                return (
+                  <Box key={role}>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                      <Typography sx={{ fontSize: 13, fontWeight: 600, color: '#334155', textTransform: 'capitalize' }}>
+                        {role.replace(/_/g, ' ')}
+                      </Typography>
+                      <Typography sx={{ fontSize: 13, fontWeight: 700, color: '#0F172A' }}>{count}</Typography>
+                    </Box>
+                    <Box sx={{ height: 8, bgcolor: '#E2E8F0', borderRadius: 1, overflow: 'hidden' }}>
                       <Box
                         sx={{
-                          position: 'absolute',
-                          right: 0,
-                          bottom: 0,
-                          width: 12,
-                          height: 12,
-                          borderRadius: '50%',
-                          bgcolor: isLiveOnline(u) ? '#16302A' : '#A89F84',
-                          border: '2px solid #EBE6D4',
+                          width: `${pct}%`,
+                          height: '100%',
+                          bgcolor: '#00796B',
+                          borderRadius: 1,
+                          minWidth: count > 0 ? 4 : 0,
                         }}
                       />
                     </Box>
-                    <Box sx={{ minWidth: 0, flex: 1 }}>
-                      <Typography sx={{ fontWeight: 800, fontSize: 14, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                        {u.firstName} {u.lastName}
-                      </Typography>
-                      <Typography sx={{ fontSize: 12, color: '#3A4540', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                        {u.email}
-                      </Typography>
-                    </Box>
-                    <Typography sx={{ fontSize: 11, fontWeight: 800, color: '#A89F84' }}>#{u.id}</Typography>
                   </Box>
-                  <Select
-                    size="small"
-                    fullWidth
-                    value={
-                      ASSIGNABLE_ROLES.includes((u.role || '').toLowerCase() as any)
-                        ? (u.role || '').toLowerCase()
-                        : 'general_user'
-                    }
-                    disabled={updatingRole}
-                    onChange={(e) => handleRoleChange(u, String(e.target.value))}
-                    sx={{ fontWeight: 700, fontSize: 12, borderRadius: '10px' }}
-                  >
-                    {ASSIGNABLE_ROLES.map((r) => (
-                      <MenuItem key={r} value={r}>
-                        {r}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+                );
+              })}
+            {Object.keys(stats.byRole).length === 0 && (
+              <Typography sx={{ fontSize: 13, color: '#64748B' }}>No user data loaded.</Typography>
+            )}
+          </Box>
+        </Box>
+      </Box>
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1.5fr 1fr' }, gap: 2 }}>
+        <Box sx={{ ...whiteCardSx, overflow: 'hidden' }}>
+          <Box sx={{ px: 2.5, py: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: 15, color: '#0F172A', fontFamily: FONT }}>
+              Property Suggestions
+            </Typography>
+            {pendingProperties.length > 0 && (
+              <Chip
+                size="small"
+                label={`${pendingProperties.length} pending`}
+                sx={{ bgcolor: '#FEF3C7', color: '#B45309', fontWeight: 700, fontSize: 11 }}
+              />
+            )}
+          </Box>
+          <Box sx={{ overflowX: 'auto' }}>
+            <Box
+              component="table"
+              sx={{
+                width: '100%',
+                borderCollapse: 'collapse',
+                fontFamily: FONT,
+                '& th, & td': {
+                  textAlign: 'left',
+                  px: 2.5,
+                  py: 1.25,
+                  fontSize: 13,
+                  borderBottom: '1px solid #F1F5F9',
+                },
+                '& th': { fontWeight: 700, color: '#64748B', fontSize: 11, letterSpacing: '0.04em' },
+                '& tbody tr': listRowHoverSx,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>USER</th>
+                  <th>PROPERTY NAME</th>
+                  <th>ACTIONS</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pendingProperties.slice(0, 8).map((p: any) => {
+                  const owner = userById.get(propOwnerId(p));
+                  return (
+                    <tr key={propId(p)}>
+                      <td>
+                        <Typography sx={{ fontWeight: 600, fontSize: 13 }}>{userDisplayName(owner)}</Typography>
+                        <Typography sx={{ fontSize: 11, color: '#94A3B8' }}>#{propOwnerId(p)}</Typography>
+                      </td>
+                      <td>
+                        <Typography sx={{ fontWeight: 600, fontSize: 13 }}>{p.title || 'Untitled'}</Typography>
+                        <Typography sx={{ fontSize: 11, color: '#94A3B8' }}>{p.status}</Typography>
+                      </td>
+                      <td>
+                        <Box sx={{ display: 'flex', gap: 0.75 }}>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            disabled={approvingProperty || rejectingProperty}
+                            onClick={() => onApproveProperty(propId(p))}
+                            sx={{
+                              textTransform: 'none',
+                              fontWeight: 600,
+                              fontSize: 12,
+                              bgcolor: '#00796B',
+                              '&:hover': { bgcolor: '#00695C' },
+                            }}
+                          >
+                            Approve
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="error"
+                            disabled={approvingProperty || rejectingProperty}
+                            onClick={() => onRejectProperty(propId(p))}
+                            sx={{ textTransform: 'none', fontWeight: 600, fontSize: 12 }}
+                          >
+                            Reject
+                          </Button>
+                        </Box>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </Box>
+            {pendingProperties.length === 0 && (
+              <Typography sx={{ p: 3, textAlign: 'center', color: '#64748B', fontSize: 13 }}>
+                No pending property suggestions.
+              </Typography>
+            )}
+          </Box>
+        </Box>
+
+        <Box
+          sx={{
+            ...whiteCardSx,
+            p: 3,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: 220,
+            textAlign: 'center',
+          }}
+        >
+          <BarChartIcon sx={{ fontSize: 48, color: '#CBD5E1', mb: 1.5 }} />
+          <Typography sx={{ fontWeight: 700, fontSize: 15, color: '#0F172A', mb: 0.5, fontFamily: FONT }}>
+            Custom Reports Widget
+          </Typography>
+          <Typography sx={{ fontSize: 13, color: '#64748B', mb: 2, maxWidth: 240 }}>
+            Build custom analytics widgets for your dashboard.
+          </Typography>
+          <Button
+            startIcon={<AddIcon />}
+            variant="outlined"
+            onClick={() => setActionMsg({ type: 'success', text: 'Coming soon — custom report widgets.' })}
+            sx={{
+              textTransform: 'none',
+              fontWeight: 600,
+              borderColor: '#E2E8F0',
+              color: '#475569',
+              fontFamily: FONT,
+            }}
+          >
+            + Add Widget
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+
+  const searchFieldSx = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 1,
+    flex: 1,
+    minWidth: 180,
+    maxWidth: 360,
+    px: 1.5,
+    py: 0.75,
+    borderRadius: '10px',
+    bgcolor: '#fff',
+    border: '1px solid #E2E8F0',
+  };
+
+  const renderUsers = () => (
+    <Box sx={{ ...whiteCardSx, overflow: 'hidden' }}>
+      <Box sx={{ p: 2, display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+        <Box sx={{ ...searchFieldSx, maxWidth: 320 }}>
+          <SearchIcon sx={{ color: '#94A3B8', fontSize: 20 }} />
+          <InputBase
+            fullWidth
+            placeholder="Search name, email, phone, role…"
+            value={userSearch}
+            onChange={(e) => setUserSearch(e.target.value)}
+            sx={{ fontSize: 14, fontFamily: FONT }}
+          />
+        </Box>
+        <Select
+          size="small"
+          value={roleFilter}
+          onChange={(e) => setRoleFilter(String(e.target.value))}
+          sx={{ minWidth: 140, borderRadius: '8px', bgcolor: '#fff', fontFamily: FONT }}
+        >
+          <MenuItem value="all">All roles</MenuItem>
+          {roleOptions.map((r) => (
+            <MenuItem key={r} value={r}>
+              {r}
+            </MenuItem>
+          ))}
+        </Select>
+        <Select
+          size="small"
+          value={userStatusFilter}
+          onChange={(e) => setUserStatusFilter(String(e.target.value))}
+          sx={{ minWidth: 140, borderRadius: '8px', bgcolor: '#fff', fontFamily: FONT }}
+        >
+          <MenuItem value="all">All status</MenuItem>
+          <MenuItem value="online">Live online</MenuItem>
+          <MenuItem value="offline">Offline</MenuItem>
+          <MenuItem value="active">Account active</MenuItem>
+          <MenuItem value="inactive">Account inactive</MenuItem>
+        </Select>
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={layoutMode}
+          onChange={(_, v) => v && setLayoutMode(v)}
+          sx={{
+            bgcolor: '#F1F5F9',
+            borderRadius: '8px',
+            '& .MuiToggleButton-root': { px: 1.1, border: 'none', color: '#64748B' },
+            '& .Mui-selected': { bgcolor: '#fff !important', color: '#00796B !important' },
+          }}
+        >
+          <ToggleButton value="list" aria-label="List view">
+            <ViewListIcon fontSize="small" />
+          </ToggleButton>
+          <ToggleButton value="grid" aria-label="Grid view">
+            <GridViewIcon fontSize="small" />
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+      <Divider />
+      {layoutMode === 'list' ? (
+        <Box sx={{ overflowX: 'auto' }}>
+          <Box
+            component="table"
+            sx={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontFamily: FONT,
+              '& th, & td': {
+                textAlign: 'left',
+                px: 2,
+                py: 1.25,
+                fontSize: 13,
+                borderBottom: '1px solid #F1F5F9',
+              },
+              '& th': { fontWeight: 700, color: '#64748B', bgcolor: '#F8FAFC', fontSize: 11 },
+              '& tbody tr': listRowHoverSx,
+            }}
+          >
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>User</th>
+                <th>Role</th>
+                <th>Live</th>
+                <th>Account</th>
+                <th>Joined</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {filteredUsers.map((u: any) => (
+                <tr key={u.id}>
+                  <td>{u.id}</td>
+                  <td>
+                    <Typography sx={{ fontWeight: 600, fontSize: 13 }}>{userDisplayName(u)}</Typography>
+                    <Typography sx={{ fontSize: 12, color: '#64748B' }}>{u.email}</Typography>
+                  </td>
+                  <td>
+                    <Select
+                      size="small"
+                      value={toUiRole(u.role)}
+                      disabled={updatingRole}
+                      onChange={(e) => handleRoleChange(u, String(e.target.value))}
+                      sx={{ minWidth: 140, fontWeight: 600, fontSize: 12, borderRadius: '8px' }}
+                    >
+                      {ASSIGNABLE_ROLES.map((r) => (
+                        <MenuItem key={r} value={r}>
+                          {r}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </td>
+                  <td>
                     <Chip
                       size="small"
                       label={isLiveOnline(u) ? 'Online' : 'Offline'}
                       color={isLiveOnline(u) ? 'success' : 'default'}
-                      sx={{ fontWeight: 700 }}
+                      sx={{ fontWeight: 600 }}
                     />
+                  </td>
+                  <td>
                     <Chip
                       size="small"
                       label={accountIsActive(u) ? 'Active' : 'Inactive'}
                       color={accountIsActive(u) ? 'success' : 'default'}
                       variant={accountIsActive(u) ? 'filled' : 'outlined'}
-                      sx={{ fontWeight: 700 }}
+                      sx={{ fontWeight: 600 }}
                     />
-                  </Box>
-                  <Typography sx={{ fontSize: 11, color: '#3A4540', fontWeight: 600 }}>
-                    Last login: {fmtDate(u.lastLoginAt, u)} · Joined {fmtDate(u.createdAt, u)}
-                  </Typography>
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    sx={{ textTransform: 'none', fontWeight: 700, borderColor: 'rgba(30,58,72,0.25)', color: ACCENT }}
-                    onClick={() => navigate('/profile', { state: { userId: u.id } })}
-                  >
-                    Open profile
-                  </Button>
-                </Box>
-              ))}
-              {filteredUsers.length === 0 && (
-                <Typography sx={{ p: 3, gridColumn: '1 / -1', textAlign: 'center', color: '#3A4540' }}>No users match.</Typography>
-              )}
-            </Box>
-            )}
-          </Box>
-        )}
-
-        {!loading && tab === 'properties' && (
-          <Box
-            sx={{
-              borderRadius: '16px',
-              bgcolor: 'rgba(235,230,212,0.82)',
-              border: '1px solid rgba(22,48,42,0.16)',
-              overflow: 'hidden',
-            }}
-          >
-            <Box sx={{ p: 1.5, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                  flex: 1,
-                  minWidth: 200,
-                  px: 1.25,
-                  py: 0.75,
-                  borderRadius: '12px',
-                  bgcolor: 'rgba(235,230,212,0.78)',
-                  border: '1px solid rgba(22,48,42,0.18)',
-                }}
-              >
-                <SearchIcon sx={{ color: '#A89F84', fontSize: 20 }} />
-                <InputBase
-                  fullWidth
-                  placeholder="Search title, city, location…"
-                  value={propertySearch}
-                  onChange={(e) => setPropertySearch(e.target.value)}
-                />
-              </Box>
-              <Select
-                size="small"
-                value={statusFilter}
-                onChange={(e) => setStatusFilter(String(e.target.value))}
-                sx={{ minWidth: 140, borderRadius: '10px', bgcolor: 'rgba(235, 230, 212,0.8)' }}
-              >
-                <MenuItem value="all">All status</MenuItem>
-                <MenuItem value="ACTIVE">ACTIVE</MenuItem>
-                <MenuItem value="INACTIVE">INACTIVE</MenuItem>
-                <MenuItem value="SOLD">SOLD</MenuItem>
-                <MenuItem value="RENTED">RENTED</MenuItem>
-              </Select>
-              <ToggleButtonGroup
-                exclusive
-                size="small"
-                value={layoutMode}
-                onChange={(_, v) => v && setLayoutMode(v)}
-                sx={{
-                  bgcolor: 'rgba(235, 230, 212,0.8)',
-                  borderRadius: '10px',
-                  '& .MuiToggleButton-root': { px: 1.1, border: 'none', color: '#3A4540' },
-                  '& .Mui-selected': { bgcolor: 'rgba(30,58,72,0.12) !important', color: `${ACCENT} !important` },
-                }}
-              >
-                <ToggleButton value="list" aria-label="List view">
-                  <ViewListIcon fontSize="small" />
-                </ToggleButton>
-                <ToggleButton value="grid" aria-label="Grid view">
-                  <GridViewIcon fontSize="small" />
-                </ToggleButton>
-              </ToggleButtonGroup>
-            </Box>
-            <Divider />
-            {layoutMode === 'list' ? (
-            <Box sx={{ overflowX: 'auto' }}>
-              <Box
-                component="table"
-                sx={{
-                  width: '100%',
-                  borderCollapse: 'collapse',
-                  '& th, & td': {
-                    textAlign: 'left',
-                    px: 1.5,
-                    py: 1.15,
-                    fontSize: 13,
-                    borderBottom: '1px solid rgba(90,70,50,0.08)',
-                    fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif',
-                  },
-                  '& th': { fontWeight: 800, color: '#3A4540', bgcolor: 'rgba(246,242,235,0.7)' },
-                  '& tbody tr': listRowHoverSx,
-                }}
-              >
-                <thead>
-                  <tr>
-                    <th>ID</th>
-                    <th>Listing</th>
-                    <th>Type</th>
-                    <th>Price</th>
-                    <th>Status</th>
-                    <th>Views</th>
-                    <th />
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredProperties.map((p: any) => (
-                    <tr key={p.propertyId}>
-                      <td>{p.propertyId}</td>
-                      <td>
-                        <Typography sx={{ fontWeight: 700, fontSize: 13 }}>{p.title}</Typography>
-                        <Typography sx={{ fontSize: 12, color: '#3A4540' }}>
-                          {p.city || p.location || '—'} · owner #{p.userId}
-                        </Typography>
-                      </td>
-                      <td>{p.propertyType}</td>
-                      <td>{fmtMoney(p.price)}</td>
-                      <td>
-                        <Chip size="small" label={p.status || (p.isActive ? 'ACTIVE' : 'INACTIVE')} sx={{ fontWeight: 700 }} />
-                      </td>
-                      <td>{p.viewCount ?? 0}</td>
-                      <td>
-                        <Box sx={{ display: 'flex', gap: 0.5 }}>
-                          <Button
-                            size="small"
-                            sx={{ textTransform: 'none', fontWeight: 700 }}
-                            onClick={() => navigate(`/property/${p.propertyId}`)}
-                          >
-                            Open
-                          </Button>
-                          <IconButton
-                            size="small"
-                            color="error"
-                            disabled={deletingProperty}
-                            onClick={() => onDeleteProperty(String(p.propertyId))}
-                            title="Delete property"
-                          >
-                            <DeleteOutlineIcon fontSize="small" />
-                          </IconButton>
-                        </Box>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </Box>
-              {filteredProperties.length === 0 && (
-                <Typography sx={{ p: 3, textAlign: 'center', color: '#3A4540' }}>No properties match.</Typography>
-              )}
-            </Box>
-            ) : (
-            <Box
-              sx={{
-                p: 1.5,
-                display: 'grid',
-                gap: 1.5,
-                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)' },
-              }}
-            >
-              {filteredProperties.map((p: any) => (
-                <Box key={p.propertyId} sx={{ ...gridCardHoverSx, p: 1.75, display: 'flex', flexDirection: 'column', gap: 1 }}>
-                  <Typography sx={{ fontWeight: 800, fontSize: 15, lineHeight: 1.3 }}>{p.title}</Typography>
-                  <Typography sx={{ fontSize: 12, color: '#3A4540', fontWeight: 600 }}>
-                    {p.city || p.location || '—'} · #{p.propertyId}
-                  </Typography>
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, alignItems: 'center' }}>
-                    <Chip size="small" label={p.propertyType || '—'} sx={{ fontWeight: 700 }} />
-                    <Chip size="small" label={p.status || (p.isActive ? 'ACTIVE' : 'INACTIVE')} sx={{ fontWeight: 700 }} />
-                  </Box>
-                  <Typography sx={{ fontWeight: 900, fontSize: 18, color: ACCENT }}>{fmtMoney(p.price)}</Typography>
-                  <Typography sx={{ fontSize: 12, color: '#3A4540' }}>{p.viewCount ?? 0} views · owner #{p.userId}</Typography>
-                  <Box sx={{ display: 'flex', gap: 0.75, mt: 'auto', pt: 0.5 }}>
+                  </td>
+                  <td>{fmtDate(u.createdAt, u)}</td>
+                  <td>
                     <Button
                       size="small"
-                      fullWidth
-                      variant="outlined"
-                      sx={{ textTransform: 'none', fontWeight: 700, borderColor: 'rgba(30,58,72,0.25)', color: ACCENT }}
-                      onClick={() => navigate(`/property/${p.propertyId}`)}
+                      sx={{ textTransform: 'none', fontWeight: 600, color: '#00796B' }}
+                      onClick={() => navigate('/profile', { state: { userId: u.id } })}
                     >
                       Open
                     </Button>
-                    <IconButton
-                      size="small"
-                      color="error"
-                      disabled={deletingProperty}
-                      onClick={() => onDeleteProperty(String(p.propertyId))}
-                      title="Delete property"
-                    >
-                      <DeleteOutlineIcon fontSize="small" />
-                    </IconButton>
-                  </Box>
-                </Box>
+                  </td>
+                </tr>
               ))}
-              {filteredProperties.length === 0 && (
-                <Typography sx={{ p: 3, gridColumn: '1 / -1', textAlign: 'center', color: '#3A4540' }}>No properties match.</Typography>
-              )}
-            </Box>
-            )}
+            </tbody>
           </Box>
-        )}
-
-        {!loading && tab === 'posts' && (
-          <Box
-            sx={{
-              borderRadius: '16px',
-              bgcolor: 'rgba(235,230,212,0.82)',
-              border: '1px solid rgba(22,48,42,0.16)',
-              overflow: 'hidden',
-            }}
-          >
-            <Box sx={{ p: 1.5, display: 'flex', justifyContent: 'flex-end' }}>
-              <ToggleButtonGroup
-                exclusive
-                size="small"
-                value={layoutMode}
-                onChange={(_, v) => v && setLayoutMode(v)}
-                sx={{
-                  bgcolor: 'rgba(235, 230, 212,0.8)',
-                  borderRadius: '10px',
-                  '& .MuiToggleButton-root': { px: 1.1, border: 'none', color: '#3A4540' },
-                  '& .Mui-selected': { bgcolor: 'rgba(30,58,72,0.12) !important', color: `${ACCENT} !important` },
-                }}
-              >
-                <ToggleButton value="list" aria-label="List view">
-                  <ViewListIcon fontSize="small" />
-                </ToggleButton>
-                <ToggleButton value="grid" aria-label="Grid view">
-                  <GridViewIcon fontSize="small" />
-                </ToggleButton>
-              </ToggleButtonGroup>
-            </Box>
-            <Divider />
-            {layoutMode === 'list' ? (
-            <Box sx={{ overflowX: 'auto' }}>
-              <Box
-                component="table"
-                sx={{
-                  width: '100%',
-                  borderCollapse: 'collapse',
-                  '& th, & td': {
-                    textAlign: 'left',
-                    px: 1.5,
-                    py: 1.15,
-                    fontSize: 13,
-                    borderBottom: '1px solid rgba(90,70,50,0.08)',
-                    fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif',
-                    verticalAlign: 'top',
-                  },
-                  '& th': { fontWeight: 800, color: '#3A4540', bgcolor: 'rgba(246,242,235,0.7)' },
-                  '& tbody tr': listRowHoverSx,
-                }}
-              >
-                <thead>
-                  <tr>
-                    <th>ID</th>
-                    <th>Post</th>
-                    <th>Author</th>
-                    <th>Engagement</th>
-                    <th>Created</th>
-                    <th />
-                  </tr>
-                </thead>
-                <tbody>
-                  {posts.map((p: any) => (
-                    <tr key={p.id}>
-                      <td>{p.id}</td>
-                      <td style={{ maxWidth: 320 }}>
-                        <Typography sx={{ fontWeight: 700, fontSize: 13 }}>{p.title || 'Untitled'}</Typography>
-                        <Typography
-                          sx={{
-                            fontSize: 12,
-                            color: '#3A4540',
-                            display: '-webkit-box',
-                            WebkitLineClamp: 2,
-                            WebkitBoxOrient: 'vertical',
-                            overflow: 'hidden',
-                          }}
-                        >
-                          {p.content}
-                        </Typography>
-                      </td>
-                      <td>
-                        {p.userFirstName} {p.userLastName}
-                        <Typography sx={{ fontSize: 11, color: '#A89F84' }}>#{p.userId}</Typography>
-                      </td>
-                      <td>
-                        {p.likeCount || 0} likes · {p.commentCount || 0} comments
-                      </td>
-                      <td>{fmtDate(p.createdAt)}</td>
-                      <td>
-                        <IconButton
-                          size="small"
-                          color="error"
-                          disabled={deletingPost}
-                          onClick={() => onDeletePost(p.id)}
-                          title="Delete post"
-                        >
-                          <DeleteOutlineIcon fontSize="small" />
-                        </IconButton>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </Box>
-              {posts.length === 0 && (
-                <Typography sx={{ p: 3, textAlign: 'center', color: '#3A4540' }}>No posts found.</Typography>
-              )}
-            </Box>
-            ) : (
+          {filteredUsers.length === 0 && (
+            <Typography sx={{ p: 3, textAlign: 'center', color: '#64748B' }}>No users match.</Typography>
+          )}
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            p: 2,
+            display: 'grid',
+            gap: 1.5,
+            gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)', lg: 'repeat(4, 1fr)' },
+          }}
+        >
+          {filteredUsers.map((u: any) => (
             <Box
+              key={u.id}
               sx={{
-                p: 1.5,
-                display: 'grid',
-                gap: 1.5,
-                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)' },
+                ...whiteCardSx,
+                p: 2,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1.25,
+                border: '1px solid #E2E8F0',
               }}
             >
-              {posts.map((p: any) => (
-                <Box key={p.id} sx={{ ...gridCardHoverSx, p: 1.75, display: 'flex', flexDirection: 'column', gap: 1 }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-                    <Typography sx={{ fontWeight: 800, fontSize: 14 }}>{p.title || 'Untitled'}</Typography>
-                    <Typography sx={{ fontSize: 11, fontWeight: 800, color: '#A89F84' }}>#{p.id}</Typography>
-                  </Box>
-                  <Typography
-                    sx={{
-                      fontSize: 12,
-                      color: '#3A4540',
-                      display: '-webkit-box',
-                      WebkitLineClamp: 3,
-                      WebkitBoxOrient: 'vertical',
-                      overflow: 'hidden',
-                      minHeight: 48,
-                    }}
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+                <Box sx={{ position: 'relative' }}>
+                  <Avatar
+                    src={u.profilePhotoSignedUrl || u.profilePhoto || undefined}
+                    sx={{ width: 44, height: 44, bgcolor: '#00796B', fontWeight: 700 }}
                   >
-                    {p.content}
+                    {(u.firstName || u.email || '?').charAt(0).toUpperCase()}
+                  </Avatar>
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      right: 0,
+                      bottom: 0,
+                      width: 12,
+                      height: 12,
+                      borderRadius: '50%',
+                      bgcolor: isLiveOnline(u) ? '#16A34A' : '#94A3B8',
+                      border: '2px solid #fff',
+                    }}
+                  />
+                </Box>
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography sx={{ fontWeight: 700, fontSize: 14, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {userDisplayName(u)}
                   </Typography>
-                  <Typography sx={{ fontSize: 12, fontWeight: 700 }}>
-                    {p.userFirstName} {p.userLastName}{' '}
-                    <Box component="span" sx={{ color: '#A89F84', fontWeight: 600 }}>#{p.userId}</Box>
+                  <Typography sx={{ fontSize: 12, color: '#64748B', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {u.email}
                   </Typography>
-                  <Typography sx={{ fontSize: 12, color: '#3A4540' }}>
+                </Box>
+                <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#94A3B8' }}>#{u.id}</Typography>
+              </Box>
+              <Select
+                size="small"
+                fullWidth
+                value={toUiRole(u.role)}
+                disabled={updatingRole}
+                onChange={(e) => handleRoleChange(u, String(e.target.value))}
+                sx={{ fontWeight: 600, fontSize: 12, borderRadius: '8px' }}
+              >
+                {ASSIGNABLE_ROLES.map((r) => (
+                  <MenuItem key={r} value={r}>
+                    {r}
+                  </MenuItem>
+                ))}
+              </Select>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+                <Chip size="small" label={isLiveOnline(u) ? 'Online' : 'Offline'} color={isLiveOnline(u) ? 'success' : 'default'} sx={{ fontWeight: 600 }} />
+                <Chip
+                  size="small"
+                  label={accountIsActive(u) ? 'Active' : 'Inactive'}
+                  color={accountIsActive(u) ? 'success' : 'default'}
+                  variant={accountIsActive(u) ? 'filled' : 'outlined'}
+                  sx={{ fontWeight: 600 }}
+                />
+              </Box>
+              <Typography sx={{ fontSize: 11, color: '#64748B', fontWeight: 500 }}>
+                Joined {fmtDate(u.createdAt, u)}
+              </Typography>
+              <Button
+                size="small"
+                variant="outlined"
+                sx={{ textTransform: 'none', fontWeight: 600, borderColor: '#E2E8F0', color: '#00796B' }}
+                onClick={() => navigate('/profile', { state: { userId: u.id } })}
+              >
+                Open profile
+              </Button>
+            </Box>
+          ))}
+          {filteredUsers.length === 0 && (
+            <Typography sx={{ p: 3, gridColumn: '1 / -1', textAlign: 'center', color: '#64748B' }}>No users match.</Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+
+  const renderProperties = () => (
+    <Box sx={{ ...whiteCardSx, overflow: 'hidden' }}>
+      <Box sx={{ p: 2, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+        <Box sx={{ ...searchFieldSx, maxWidth: 320 }}>
+          <SearchIcon sx={{ color: '#94A3B8', fontSize: 20 }} />
+          <InputBase
+            fullWidth
+            placeholder="Search title, city, location…"
+            value={propertySearch}
+            onChange={(e) => setPropertySearch(e.target.value)}
+            sx={{ fontSize: 14, fontFamily: FONT }}
+          />
+        </Box>
+        <Select
+          size="small"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(String(e.target.value))}
+          sx={{ minWidth: 140, borderRadius: '8px', bgcolor: '#fff', fontFamily: FONT }}
+        >
+          <MenuItem value="all">All status</MenuItem>
+          <MenuItem value="ACTIVE">ACTIVE</MenuItem>
+          <MenuItem value="INACTIVE">INACTIVE</MenuItem>
+          <MenuItem value="SOLD">SOLD</MenuItem>
+          <MenuItem value="RENTED">RENTED</MenuItem>
+          <MenuItem value="PENDING">PENDING</MenuItem>
+          <MenuItem value="DRAFT">DRAFT</MenuItem>
+        </Select>
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={layoutMode}
+          onChange={(_, v) => v && setLayoutMode(v)}
+          sx={{
+            bgcolor: '#F1F5F9',
+            borderRadius: '8px',
+            '& .MuiToggleButton-root': { px: 1.1, border: 'none', color: '#64748B' },
+            '& .Mui-selected': { bgcolor: '#fff !important', color: '#00796B !important' },
+          }}
+        >
+          <ToggleButton value="list" aria-label="List view">
+            <ViewListIcon fontSize="small" />
+          </ToggleButton>
+          <ToggleButton value="grid" aria-label="Grid view">
+            <GridViewIcon fontSize="small" />
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+      <Divider />
+      {layoutMode === 'list' ? (
+        <Box sx={{ overflowX: 'auto' }}>
+          <Box
+            component="table"
+            sx={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontFamily: FONT,
+              '& th, & td': {
+                textAlign: 'left',
+                px: 2,
+                py: 1.25,
+                fontSize: 13,
+                borderBottom: '1px solid #F1F5F9',
+              },
+              '& th': { fontWeight: 700, color: '#64748B', bgcolor: '#F8FAFC', fontSize: 11 },
+              '& tbody tr': listRowHoverSx,
+            }}
+          >
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Listing</th>
+                <th>Type</th>
+                <th>Price</th>
+                <th>Status</th>
+                <th>Views</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {filteredProperties.map((p: any) => (
+                <tr key={propId(p)}>
+                  <td>{propId(p)}</td>
+                  <td>
+                    <Typography sx={{ fontWeight: 600, fontSize: 13 }}>{p.title}</Typography>
+                    <Typography sx={{ fontSize: 12, color: '#64748B' }}>
+                      {p.city || p.location || '—'} · owner #{propOwnerId(p)}
+                    </Typography>
+                  </td>
+                  <td>{p.propertyType}</td>
+                  <td>{fmtMoney(p.price)}</td>
+                  <td>
+                    <Chip size="small" label={p.status || (p.isActive ? 'ACTIVE' : 'INACTIVE')} sx={{ fontWeight: 600 }} />
+                  </td>
+                  <td>{p.viewCount ?? 0}</td>
+                  <td>
+                    <Box sx={{ display: 'flex', gap: 0.5 }}>
+                      <Button
+                        size="small"
+                        sx={{ textTransform: 'none', fontWeight: 600, color: '#00796B' }}
+                        onClick={() => navigate(`/property/${propId(p)}`)}
+                      >
+                        Open
+                      </Button>
+                      <IconButton
+                        size="small"
+                        color="error"
+                        disabled={deletingProperty}
+                        onClick={() => onDeleteProperty(String(propId(p)))}
+                        title="Delete property"
+                      >
+                        <DeleteOutlineIcon fontSize="small" />
+                      </IconButton>
+                    </Box>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Box>
+          {filteredProperties.length === 0 && (
+            <Typography sx={{ p: 3, textAlign: 'center', color: '#64748B' }}>No properties match.</Typography>
+          )}
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            p: 2,
+            display: 'grid',
+            gap: 1.5,
+            gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)' },
+          }}
+        >
+          {filteredProperties.map((p: any) => (
+            <Box key={propId(p)} sx={{ ...whiteCardSx, p: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Typography sx={{ fontWeight: 700, fontSize: 15, lineHeight: 1.3 }}>{p.title}</Typography>
+              <Typography sx={{ fontSize: 12, color: '#64748B', fontWeight: 500 }}>
+                {p.city || p.location || '—'} · #{propId(p)}
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, alignItems: 'center' }}>
+                <Chip size="small" label={p.propertyType || '—'} sx={{ fontWeight: 600 }} />
+                <Chip size="small" label={p.status || (p.isActive ? 'ACTIVE' : 'INACTIVE')} sx={{ fontWeight: 600 }} />
+              </Box>
+              <Typography sx={{ fontWeight: 700, fontSize: 18, color: '#00796B' }}>{fmtMoney(p.price)}</Typography>
+              <Typography sx={{ fontSize: 12, color: '#64748B' }}>{p.viewCount ?? 0} views · owner #{propOwnerId(p)}</Typography>
+              <Box sx={{ display: 'flex', gap: 0.75, mt: 'auto', pt: 0.5 }}>
+                <Button
+                  size="small"
+                  fullWidth
+                  variant="outlined"
+                  sx={{ textTransform: 'none', fontWeight: 600, borderColor: '#E2E8F0', color: '#00796B' }}
+                  onClick={() => navigate(`/property/${propId(p)}`)}
+                >
+                  Open
+                </Button>
+                <IconButton
+                  size="small"
+                  color="error"
+                  disabled={deletingProperty}
+                  onClick={() => onDeleteProperty(String(propId(p)))}
+                  title="Delete property"
+                >
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            </Box>
+          ))}
+          {filteredProperties.length === 0 && (
+            <Typography sx={{ p: 3, gridColumn: '1 / -1', textAlign: 'center', color: '#64748B' }}>No properties match.</Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+
+  const renderPosts = () => (
+    <Box sx={{ ...whiteCardSx, overflow: 'hidden' }}>
+      <Box sx={{ p: 2, display: 'flex', justifyContent: 'flex-end' }}>
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={layoutMode}
+          onChange={(_, v) => v && setLayoutMode(v)}
+          sx={{
+            bgcolor: '#F1F5F9',
+            borderRadius: '8px',
+            '& .MuiToggleButton-root': { px: 1.1, border: 'none', color: '#64748B' },
+            '& .Mui-selected': { bgcolor: '#fff !important', color: '#00796B !important' },
+          }}
+        >
+          <ToggleButton value="list" aria-label="List view">
+            <ViewListIcon fontSize="small" />
+          </ToggleButton>
+          <ToggleButton value="grid" aria-label="Grid view">
+            <GridViewIcon fontSize="small" />
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+      <Divider />
+      {layoutMode === 'list' ? (
+        <Box sx={{ overflowX: 'auto' }}>
+          <Box
+            component="table"
+            sx={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontFamily: FONT,
+              '& th, & td': {
+                textAlign: 'left',
+                px: 2,
+                py: 1.25,
+                fontSize: 13,
+                borderBottom: '1px solid #F1F5F9',
+                verticalAlign: 'top',
+              },
+              '& th': { fontWeight: 700, color: '#64748B', bgcolor: '#F8FAFC', fontSize: 11 },
+              '& tbody tr': listRowHoverSx,
+            }}
+          >
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Post</th>
+                <th>Author</th>
+                <th>Engagement</th>
+                <th>Created</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {posts.map((p: any) => (
+                <tr key={p.id}>
+                  <td>{p.id}</td>
+                  <td style={{ maxWidth: 320 }}>
+                    <Typography sx={{ fontWeight: 600, fontSize: 13 }}>{p.title || 'Untitled'}</Typography>
+                    <Typography
+                      sx={{
+                        fontSize: 12,
+                        color: '#64748B',
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      {p.content}
+                    </Typography>
+                  </td>
+                  <td>
+                    {p.userFirstName} {p.userLastName}
+                    <Typography sx={{ fontSize: 11, color: '#94A3B8' }}>#{propOwnerId(p)}</Typography>
+                  </td>
+                  <td>
                     {p.likeCount || 0} likes · {p.commentCount || 0} comments
-                  </Typography>
-                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 'auto' }}>
-                    <Typography sx={{ fontSize: 11, color: '#3A4540' }}>{fmtDate(p.createdAt)}</Typography>
+                    {(p.reportCount || 0) > 0 && (
+                      <Typography sx={{ fontSize: 11, color: '#DC2626', fontWeight: 600 }}>
+                        {p.reportCount} reports
+                      </Typography>
+                    )}
+                  </td>
+                  <td>{fmtDate(p.createdAt)}</td>
+                  <td>
                     <IconButton
                       size="small"
                       color="error"
@@ -1214,16 +1497,429 @@ const AdminDashboard: React.FC = () => {
                     >
                       <DeleteOutlineIcon fontSize="small" />
                     </IconButton>
-                  </Box>
-                </Box>
+                  </td>
+                </tr>
               ))}
-              {posts.length === 0 && (
-                <Typography sx={{ p: 3, gridColumn: '1 / -1', textAlign: 'center', color: '#3A4540' }}>No posts found.</Typography>
-              )}
-            </Box>
-            )}
+            </tbody>
           </Box>
+          {posts.length === 0 && (
+            <Typography sx={{ p: 3, textAlign: 'center', color: '#64748B' }}>No posts found.</Typography>
+          )}
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            p: 2,
+            display: 'grid',
+            gap: 1.5,
+            gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)' },
+          }}
+        >
+          {posts.map((p: any) => (
+            <Box key={p.id} sx={{ ...whiteCardSx, p: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: 14 }}>{p.title || 'Untitled'}</Typography>
+                <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#94A3B8' }}>#{p.id}</Typography>
+              </Box>
+              <Typography
+                sx={{
+                  fontSize: 12,
+                  color: '#64748B',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 3,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  minHeight: 48,
+                }}
+              >
+                {p.content}
+              </Typography>
+              <Typography sx={{ fontSize: 12, fontWeight: 600 }}>
+                {p.userFirstName} {p.userLastName}{' '}
+                <Box component="span" sx={{ color: '#94A3B8', fontWeight: 500 }}>#{propOwnerId(p)}</Box>
+              </Typography>
+              <Typography sx={{ fontSize: 12, color: '#64748B' }}>
+                {p.likeCount || 0} likes · {p.commentCount || 0} comments
+              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 'auto' }}>
+                <Typography sx={{ fontSize: 11, color: '#64748B' }}>{fmtDate(p.createdAt)}</Typography>
+                <IconButton
+                  size="small"
+                  color="error"
+                  disabled={deletingPost}
+                  onClick={() => onDeletePost(p.id)}
+                  title="Delete post"
+                >
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            </Box>
+          ))}
+          {posts.length === 0 && (
+            <Typography sx={{ p: 3, gridColumn: '1 / -1', textAlign: 'center', color: '#64748B' }}>No posts found.</Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+
+  const renderReports = () => (
+    <Box sx={{ ...whiteCardSx, overflow: 'hidden' }}>
+      {reportsError && (
+        <Alert severity="info" sx={{ m: 2, borderRadius: 2 }}>
+          Report data unavailable — you may lack permission or the reports service is offline.
+        </Alert>
+      )}
+      {reportsLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress sx={{ color: '#00796B' }} />
+        </Box>
+      ) : (
+        <Box sx={{ overflowX: 'auto' }}>
+          <Box
+            component="table"
+            sx={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontFamily: FONT,
+              '& th, & td': {
+                textAlign: 'left',
+                px: 2,
+                py: 1.25,
+                fontSize: 13,
+                borderBottom: '1px solid #F1F5F9',
+                verticalAlign: 'top',
+              },
+              '& th': { fontWeight: 700, color: '#64748B', bgcolor: '#F8FAFC', fontSize: 11 },
+              '& tbody tr': listRowHoverSx,
+            }}
+          >
+            <thead>
+              <tr>
+                <th>Report</th>
+                <th>Entity</th>
+                <th>Reason</th>
+                <th>Reporter</th>
+                <th>Created</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {reports.map((r: any) => (
+                <tr key={r.id}>
+                  <td>
+                    <Typography sx={{ fontWeight: 600, fontSize: 13 }}>{r.reportCode || r.id}</Typography>
+                    <Chip size="small" label={r.status} sx={{ fontWeight: 600, mt: 0.5 }} />
+                  </td>
+                  <td>
+                    <Typography sx={{ fontSize: 13, fontWeight: 600 }}>{r.entityType}</Typography>
+                    <Typography sx={{ fontSize: 11, color: '#94A3B8' }}>ID: {r.entityId}</Typography>
+                  </td>
+                  <td>
+                    <Typography sx={{ fontSize: 13, fontWeight: 600 }}>{r.reasonCode || '—'}</Typography>
+                    {r.description && (
+                      <Typography sx={{ fontSize: 12, color: '#64748B', maxWidth: 240 }}>{r.description}</Typography>
+                    )}
+                  </td>
+                  <td>
+                    {userDisplayName(userById.get(String(r.reportedUserId || r.reportedBy)))}
+                    <Typography sx={{ fontSize: 11, color: '#94A3B8' }}>{r.reportedBy}</Typography>
+                  </td>
+                  <td>{fmtDate(r.createdAt)}</td>
+                  <td>
+                    <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+                      <Button
+                        size="small"
+                        variant="contained"
+                        disabled={updatingReport}
+                        onClick={() => onUpdateReport(r.id, 'RESOLVED')}
+                        sx={{
+                          textTransform: 'none',
+                          fontWeight: 600,
+                          fontSize: 12,
+                          bgcolor: '#00796B',
+                          '&:hover': { bgcolor: '#00695C' },
+                        }}
+                      >
+                        Resolve
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        color="inherit"
+                        disabled={updatingReport}
+                        onClick={() => onUpdateReport(r.id, 'REJECTED')}
+                        sx={{ textTransform: 'none', fontWeight: 600, fontSize: 12 }}
+                      >
+                        Dismiss
+                      </Button>
+                    </Box>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Box>
+          {reports.length === 0 && !reportsError && (
+            <Typography sx={{ p: 3, textAlign: 'center', color: '#64748B' }}>No pending reports.</Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+
+  const renderApprovals = () => (
+    <Box sx={{ ...whiteCardSx, overflow: 'hidden' }}>
+      <Box sx={{ px: 2.5, py: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography sx={{ fontWeight: 700, fontSize: 15, color: '#0F172A', fontFamily: FONT }}>
+          Pending Property Approvals
+        </Typography>
+        {pendingProperties.length > 0 && (
+          <Chip
+            size="small"
+            label={`${pendingProperties.length} pending`}
+            sx={{ bgcolor: '#FEF3C7', color: '#B45309', fontWeight: 700, fontSize: 11 }}
+          />
         )}
+      </Box>
+      <Box sx={{ overflowX: 'auto' }}>
+        <Box
+          component="table"
+          sx={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: FONT,
+            '& th, & td': {
+              textAlign: 'left',
+              px: 2.5,
+              py: 1.25,
+              fontSize: 13,
+              borderBottom: '1px solid #F1F5F9',
+            },
+            '& th': { fontWeight: 700, color: '#64748B', fontSize: 11, bgcolor: '#F8FAFC' },
+            '& tbody tr': listRowHoverSx,
+          }}
+        >
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>USER</th>
+              <th>PROPERTY NAME</th>
+              <th>STATUS</th>
+              <th>CREATED</th>
+              <th>ACTIONS</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pendingProperties.map((p: any) => {
+              const owner = userById.get(propOwnerId(p));
+              return (
+                <tr key={propId(p)}>
+                  <td>{propId(p)}</td>
+                  <td>
+                    <Typography sx={{ fontWeight: 600, fontSize: 13 }}>{userDisplayName(owner)}</Typography>
+                    <Typography sx={{ fontSize: 11, color: '#94A3B8' }}>#{propOwnerId(p)}</Typography>
+                  </td>
+                  <td>
+                    <Typography sx={{ fontWeight: 600, fontSize: 13 }}>{p.title || 'Untitled'}</Typography>
+                    <Typography sx={{ fontSize: 11, color: '#94A3B8' }}>
+                      {p.city || p.location || '—'} · {fmtMoney(p.price)}
+                    </Typography>
+                  </td>
+                  <td>
+                    <Chip size="small" label={p.status} sx={{ fontWeight: 600 }} />
+                  </td>
+                  <td>{fmtDate(p.createdAt)}</td>
+                  <td>
+                    <Box sx={{ display: 'flex', gap: 0.75 }}>
+                      <Button
+                        size="small"
+                        variant="contained"
+                        disabled={approvingProperty || rejectingProperty}
+                        onClick={() => onApproveProperty(propId(p))}
+                        sx={{
+                          textTransform: 'none',
+                          fontWeight: 600,
+                          fontSize: 12,
+                          bgcolor: '#00796B',
+                          '&:hover': { bgcolor: '#00695C' },
+                        }}
+                      >
+                        Approve
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        color="error"
+                        disabled={approvingProperty || rejectingProperty}
+                        onClick={() => onRejectProperty(propId(p))}
+                        sx={{ textTransform: 'none', fontWeight: 600, fontSize: 12 }}
+                      >
+                        Reject
+                      </Button>
+                    </Box>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </Box>
+        {pendingProperties.length === 0 && (
+          <Typography sx={{ p: 3, textAlign: 'center', color: '#64748B' }}>No pending approvals.</Typography>
+        )}
+      </Box>
+    </Box>
+  );
+
+  const renderContent = () => {
+    if (loading && tab !== 'reports') {
+      return (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress sx={{ color: '#00796B' }} />
+        </Box>
+      );
+    }
+    switch (tab) {
+      case 'overview':
+        return renderOverview();
+      case 'users':
+        return renderUsers();
+      case 'posts':
+        return renderPosts();
+      case 'properties':
+        return renderProperties();
+      case 'reports':
+        return renderReports();
+      case 'approvals':
+        return renderApprovals();
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh', bgcolor: MAIN_BG, fontFamily: FONT }}>
+      {!isMobile && (
+        <Box
+          component="aside"
+          sx={{
+            width: SIDEBAR_WIDTH,
+            flexShrink: 0,
+            position: 'sticky',
+            top: 0,
+            height: '100vh',
+            zIndex: 30,
+          }}
+        >
+          {sidebarContent}
+        </Box>
+      )}
+
+      <Drawer
+        open={isMobile && sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+        ModalProps={{ keepMounted: true }}
+        sx={{ display: { xs: 'block', md: 'none' } }}
+      >
+        {sidebarContent}
+      </Drawer>
+
+      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+        <Box
+          component="header"
+          sx={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 20,
+            bgcolor: MAIN_BG,
+            borderBottom: '1px solid #E2E8F0',
+            px: { xs: 2, sm: 3 },
+            py: 1.5,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+            {isMobile && (
+              <IconButton onClick={() => setSidebarOpen(true)} sx={{ color: '#334155' }}>
+                <MenuIcon />
+              </IconButton>
+            )}
+            <Typography
+              sx={{
+                fontWeight: 700,
+                fontSize: { xs: '1.15rem', sm: '1.35rem' },
+                color: '#0F172A',
+                fontFamily: FONT,
+                mr: 'auto',
+              }}
+            >
+              {PAGE_TITLES[tab]}
+            </Typography>
+
+            <Box sx={searchFieldSx}>
+              <SearchIcon sx={{ color: '#94A3B8', fontSize: 20 }} />
+              <InputBase
+                fullWidth
+                placeholder="Search…"
+                value={headerSearch}
+                onChange={(e) => setHeaderSearch(e.target.value)}
+                sx={{ fontSize: 14, fontFamily: FONT }}
+              />
+            </Box>
+
+            <Tooltip title="Refresh data">
+              <IconButton onClick={refreshAll} sx={{ color: '#64748B' }}>
+                <RefreshIcon />
+              </IconButton>
+            </Tooltip>
+
+            <Tooltip title="Notifications (coming soon)">
+              <IconButton sx={{ color: '#64748B' }}>
+                <Badge variant="dot" color="error" overlap="circular">
+                  <NotificationsNoneIcon />
+                </Badge>
+              </IconButton>
+            </Tooltip>
+
+            <Tooltip title="Settings">
+              <IconButton sx={{ color: '#64748B' }}>
+                <SettingsOutlinedIcon />
+              </IconButton>
+            </Tooltip>
+
+            <Tooltip title="Logout">
+              <IconButton onClick={handleLogout} sx={{ color: '#64748B' }}>
+                <LogoutIcon />
+              </IconButton>
+            </Tooltip>
+
+            <Button
+              startIcon={<HomeIcon />}
+              onClick={() => navigate('/home')}
+              sx={{
+                textTransform: 'none',
+                fontWeight: 600,
+                color: '#00796B',
+                fontFamily: FONT,
+                display: { xs: 'none', sm: 'inline-flex' },
+              }}
+            >
+              App home
+            </Button>
+          </Box>
+        </Box>
+
+        <Box component="main" sx={{ flex: 1, px: { xs: 2, sm: 3 }, py: 3 }}>
+          {(usersError || propsError || pendingPropsError || postsError) && (
+            <Alert severity="warning" sx={{ mb: 2, borderRadius: 2 }}>
+              Some admin data failed to load. Showing whatever is available.
+            </Alert>
+          )}
+          {actionMsg && (
+            <Alert severity={actionMsg.type} sx={{ mb: 2, borderRadius: 2 }} onClose={() => setActionMsg(null)}>
+              {actionMsg.text}
+            </Alert>
+          )}
+          <TabEnter tabKey={tab}>{renderContent()}</TabEnter>
+        </Box>
       </Box>
     </Box>
   );

--- a/src/components/comments/CommentComposer.tsx
+++ b/src/components/comments/CommentComposer.tsx
@@ -86,7 +86,9 @@ const CommentComposer: React.FC<CommentComposerProps> = ({
       setMentionIndex(0);
       if (mentionTimerRef.current) clearTimeout(mentionTimerRef.current);
       mentionTimerRef.current = setTimeout(() => {
-        searchUsers({ variables: { search: active.query.trim() || '', page: 1, limit: 8 } });
+        const term = active.query.trim();
+        if (term.length < 2) return;
+        searchUsers({ variables: { search: term, page: 1, limit: 8 }, errorPolicy: 'all' });
       }, 200);
     } else {
       setMentionOpen(false);

--- a/src/components/comments/CommentListItem.tsx
+++ b/src/components/comments/CommentListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Avatar,
   Box,
@@ -7,7 +7,6 @@ import {
   InputBase,
   Menu,
   MenuItem,
-  Stack,
   Typography,
 } from '@mui/material';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
@@ -20,6 +19,13 @@ import {
   COMMENT_REACTION_EMOJIS,
   normalizeReactionEmoji,
 } from './commentReactions';
+
+/** Indent caps so deep threads stay readable on mobile. */
+const MAX_INDENT_DEPTH = 4;
+/** Collapse nested branches (depth >= this) by default. */
+const COLLAPSE_FROM_DEPTH = 2;
+/** Within an expanded branch, show this many before "Show more". */
+const INITIAL_VISIBLE_REPLIES = 3;
 
 export type CommentListItemProps = {
   comment: any;
@@ -34,18 +40,20 @@ export type CommentListItemProps = {
   replyText: string;
   setReplyText: (text: string) => void;
   replying?: boolean;
-  onReply: (text: string) => void | Promise<void>;
+  /** Parent id for the reply being composed is the bubble the user clicked Reply on. */
+  onReply: (text: string, parentCommentId: string) => void | Promise<void>;
   onReactComment: (commentId: string, emoji: string) => void | Promise<void>;
   onEditComment: (commentId: string, text: string) => void | Promise<void>;
   onDeleteComment: (commentId: string) => void | Promise<void>;
   showReplyAction?: boolean;
+  depth?: number;
 };
 
 const defaultFormatTime = (value: any) => formatDateTime(value);
 
 const CommentBubble: React.FC<{
   item: any;
-  isReply?: boolean;
+  depth?: number;
   currentUserId?: string | null;
   formatTime: (value: any) => string;
   likedComments: { [commentId: string]: boolean };
@@ -59,7 +67,7 @@ const CommentBubble: React.FC<{
   onDeleteComment: (commentId: string) => void | Promise<void>;
 }> = ({
   item,
-  isReply = false,
+  depth = 0,
   currentUserId,
   formatTime,
   likedComments,
@@ -78,6 +86,7 @@ const CommentBubble: React.FC<{
   const [saving, setSaving] = useState(false);
   const [animating, setAnimating] = useState(false);
 
+  const isReply = depth > 0;
   const isOwner = currentUserId != null && String(item.userId) === String(currentUserId);
   const reaction = normalizeReactionEmoji(commentReactions[item.id]) || (likedComments[item.id] ? '❤️' : null);
   const likeCount = commentLikeCounts[item.id] !== undefined
@@ -111,7 +120,7 @@ const CommentBubble: React.FC<{
   };
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: isReply ? 1 : 1.25, minWidth: 0, mb: isReply ? 1.25 : 0 }}>
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: isReply ? 1 : 1.25, minWidth: 0, mb: 0 }}>
       <Avatar
         src={item.profilePhotoSignedUrl || item.profilePhoto || undefined}
         sx={{
@@ -252,7 +261,6 @@ const CommentBubble: React.FC<{
                 e.stopPropagation();
                 setAnimating(true);
                 setTimeout(() => setAnimating(false), 500);
-                // Direct like/unlike with ❤️ — emoji picker lives under ⋯
                 await onReactComment(item.id, '❤️');
               }}
               disabled={likingComment}
@@ -363,16 +371,35 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
   onEditComment,
   onDeleteComment,
   showReplyAction = true,
+  depth = 0,
 }) => {
+  const replies = useMemo(
+    () => (Array.isArray(comment.replies) ? comment.replies : []),
+    [comment.replies],
+  );
+  const [branchOpen, setBranchOpen] = useState(depth < COLLAPSE_FROM_DEPTH);
+  const [showAllReplies, setShowAllReplies] = useState(false);
+
+  const indentDepth = Math.min(depth, MAX_INDENT_DEPTH);
+  const visibleReplies = branchOpen
+    ? (showAllReplies ? replies : replies.slice(0, INITIAL_VISIBLE_REPLIES))
+    : [];
+  const hiddenCount = branchOpen
+    ? Math.max(0, replies.length - INITIAL_VISIBLE_REPLIES)
+    : replies.length;
+
   const handleSendReply = useCallback(async () => {
     if (!replyText.trim()) return;
-    await onReply(replyText);
-  }, [onReply, replyText]);
+    await onReply(replyText, String(comment.id));
+  }, [onReply, replyText, comment.id]);
+
+  const isComposingHere = String(replyingCommentId) === String(comment.id);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
       <CommentBubble
         item={comment}
+        depth={depth}
         currentUserId={currentUserId}
         formatTime={formatTime}
         likedComments={likedComments}
@@ -386,11 +413,112 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
         onDeleteComment={onDeleteComment}
       />
 
-      {comment.replies && comment.replies.length > 0 && (
-        <Stack spacing={1.1} sx={{ mt: 1.1, ml: { xs: 2.25, sm: 4.5 } }}>
-          {comment.replies.map((reply: any) => (
+      {replies.length > 0 && !branchOpen && (
+        <Button
+          size="small"
+          onClick={() => setBranchOpen(true)}
+          sx={{
+            alignSelf: 'flex-start',
+            mt: 0.75,
+            ml: { xs: 1.5 + indentDepth * 1.25, sm: 3 + indentDepth * 1.5 },
+            textTransform: 'none',
+            fontWeight: 700,
+            fontSize: 12.5,
+            color: '#16302A',
+            px: 0.5,
+            minWidth: 0,
+          }}
+        >
+          View {replies.length} {replies.length === 1 ? 'reply' : 'replies'}
+        </Button>
+      )}
+
+      {(visibleReplies.length > 0 || isComposingHere) && (
+        <Box
+          sx={{
+            mt: 1,
+            ml: { xs: 1.25 + indentDepth * 1.1, sm: 2.75 + indentDepth * 1.35 },
+            pl: { xs: 1.1, sm: 1.35 },
+            borderLeft: '2px solid rgba(22,48,42,0.14)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1.15,
+          }}
+        >
+          {visibleReplies.map((reply: any) => (
+            <Box key={reply.id} sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.65, minWidth: 0 }}>
+              {depth < MAX_INDENT_DEPTH && (
+                <SubdirectoryArrowRightIcon
+                  aria-hidden
+                  sx={{ mt: 0.85, flexShrink: 0, fontSize: 18, color: '#7A847C' }}
+                />
+              )}
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <CommentListItem
+                  comment={reply}
+                  depth={depth + 1}
+                  currentUserId={currentUserId}
+                  formatTime={formatTime}
+                  likedComments={likedComments}
+                  commentReactions={commentReactions}
+                  commentLikeCounts={commentLikeCounts}
+                  likingComment={likingComment}
+                  replyingCommentId={replyingCommentId}
+                  setReplyingCommentId={setReplyingCommentId}
+                  replyText={replyText}
+                  setReplyText={setReplyText}
+                  replying={replying}
+                  onReply={onReply}
+                  onReactComment={onReactComment}
+                  onEditComment={onEditComment}
+                  onDeleteComment={onDeleteComment}
+                  showReplyAction={showReplyAction}
+                />
+              </Box>
+            </Box>
+          ))}
+
+          {branchOpen && !showAllReplies && replies.length > INITIAL_VISIBLE_REPLIES && (
+            <Button
+              size="small"
+              onClick={() => setShowAllReplies(true)}
+              sx={{
+                alignSelf: 'flex-start',
+                textTransform: 'none',
+                fontWeight: 700,
+                fontSize: 12.5,
+                color: '#16302A',
+                px: 0.5,
+                minWidth: 0,
+              }}
+            >
+              Show {hiddenCount} more {hiddenCount === 1 ? 'reply' : 'replies'}
+            </Button>
+          )}
+
+          {branchOpen && depth >= COLLAPSE_FROM_DEPTH && (
+            <Button
+              size="small"
+              onClick={() => {
+                setBranchOpen(false);
+                setShowAllReplies(false);
+              }}
+              sx={{
+                alignSelf: 'flex-start',
+                textTransform: 'none',
+                fontWeight: 600,
+                fontSize: 12,
+                color: '#5C675F',
+                px: 0.5,
+                minWidth: 0,
+              }}
+            >
+              Hide replies
+            </Button>
+          )}
+
+          {isComposingHere && (
             <Box
-              key={reply.id}
               sx={{
                 display: 'flex',
                 alignItems: 'flex-start',
@@ -400,106 +528,67 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
             >
               <SubdirectoryArrowRightIcon
                 aria-hidden
-                sx={{
-                  mt: 0.85,
-                  flexShrink: 0,
-                  fontSize: 20,
-                  color: '#7A847C',
-                }}
+                sx={{ mt: 1.15, flexShrink: 0, fontSize: 18, color: '#7A847C' }}
               />
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                <CommentBubble
-                  item={reply}
-                  isReply
-                  currentUserId={currentUserId}
-                  formatTime={formatTime}
-                  likedComments={likedComments}
-                  commentReactions={commentReactions}
-                  commentLikeCounts={commentLikeCounts}
-                  likingComment={likingComment}
-                  showReplyAction={false}
-                  onReactComment={onReactComment}
-                  onEditComment={onEditComment}
-                  onDeleteComment={onDeleteComment}
+              <Box
+                sx={{
+                  flex: 1,
+                  minWidth: 0,
+                  display: 'flex',
+                  flexDirection: { xs: 'column', sm: 'row' },
+                  gap: 1,
+                  alignItems: { xs: 'stretch', sm: 'center' },
+                }}
+              >
+                <InputBase
+                  value={replyText}
+                  onChange={(e) => setReplyText(e.target.value)}
+                  placeholder="Write a reply..."
+                  autoFocus
+                  sx={{
+                    bgcolor: '#EBE6D4',
+                    px: 1.5,
+                    py: 1,
+                    borderRadius: 999,
+                    fontSize: 14,
+                    fontWeight: 600,
+                    flex: 1,
+                    minWidth: 0,
+                    border: '1.5px solid #DDD6C0',
+                  }}
+                  multiline
+                  minRows={1}
+                  maxRows={3}
                 />
+                <Box sx={{ display: 'flex', gap: 0.75 }}>
+                  <Button
+                    variant="contained"
+                    disableElevation
+                    sx={{
+                      bgcolor: '#16302A',
+                      fontWeight: 800,
+                      borderRadius: 999,
+                      px: 2,
+                      py: 0.85,
+                      minWidth: 0,
+                      textTransform: 'none',
+                      '&:hover': { bgcolor: '#0F221C' },
+                    }}
+                    onClick={handleSendReply}
+                    disabled={replying || !replyText.trim()}
+                  >
+                    Send
+                  </Button>
+                  <Button
+                    sx={{ color: '#3A4540', fontWeight: 700, borderRadius: 999, px: 1.5, textTransform: 'none' }}
+                    onClick={() => { setReplyingCommentId(null); setReplyText(''); }}
+                  >
+                    Cancel
+                  </Button>
+                </Box>
               </Box>
             </Box>
-          ))}
-        </Stack>
-      )}
-
-      {String(replyingCommentId) === String(comment.id) && (
-        <Box
-          sx={{
-            mt: 1.25,
-            ml: { xs: 2.25, sm: 4.5 },
-            display: 'flex',
-            alignItems: 'flex-start',
-            gap: 0.75,
-            minWidth: 0,
-          }}
-        >
-          <SubdirectoryArrowRightIcon
-            aria-hidden
-            sx={{ mt: 1.15, flexShrink: 0, fontSize: 20, color: '#7A847C' }}
-          />
-          <Box
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              display: 'flex',
-              flexDirection: { xs: 'column', sm: 'row' },
-              gap: 1,
-              alignItems: { xs: 'stretch', sm: 'center' },
-            }}
-          >
-          <InputBase
-            value={replyText}
-            onChange={(e) => setReplyText(e.target.value)}
-            placeholder="Write a reply..."
-            autoFocus
-            sx={{
-              bgcolor: '#EBE6D4',
-              px: 1.5,
-              py: 1,
-              borderRadius: 999,
-              fontSize: 14,
-              fontWeight: 600,
-              flex: 1,
-              minWidth: 0,
-              border: '1.5px solid #DDD6C0',
-            }}
-            multiline
-            minRows={1}
-            maxRows={3}
-          />
-          <Box sx={{ display: 'flex', gap: 0.75 }}>
-            <Button
-              variant="contained"
-              disableElevation
-              sx={{
-                bgcolor: '#16302A',
-                fontWeight: 800,
-                borderRadius: 999,
-                px: 2,
-                py: 0.85,
-                minWidth: 0,
-                textTransform: 'none',
-                '&:hover': { bgcolor: '#0F221C' },
-              }}
-              onClick={handleSendReply}
-              disabled={replying || !replyText.trim()}
-            >
-              Send
-            </Button>
-            <Button
-              sx={{ color: '#3A4540', fontWeight: 700, borderRadius: 999, px: 1.5, textTransform: 'none' }}
-              onClick={() => { setReplyingCommentId(null); setReplyText(''); }}
-            >
-              Cancel
-            </Button>
-          </Box>
-          </Box>
+          )}
         </Box>
       )}
     </Box>

--- a/src/components/motion/PageEnter.tsx
+++ b/src/components/motion/PageEnter.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box, BoxProps } from '@mui/material';
+import { ZPC_MOTION } from '../../theme/motion';
+
+type PageEnterProps = BoxProps & {
+  /** Remount key — usually pathname */
+  enterKey?: string | number;
+};
+
+/**
+ * Soft fade + rise when a route/page mounts.
+ * Prefer wrapping each page root once (or wrapping Routes with location.key).
+ */
+const PageEnter: React.FC<PageEnterProps> = ({ enterKey, children, sx, ...rest }) => (
+  <Box
+    key={enterKey}
+    sx={{
+      width: '100%',
+      minHeight: '100%',
+      animation: `zpcPageIn ${ZPC_MOTION.page}ms ${ZPC_MOTION.ease} both`,
+      '@media (prefers-reduced-motion: reduce)': {
+        animation: 'none',
+      },
+      ...sx,
+    }}
+    {...rest}
+  >
+    {children}
+  </Box>
+);
+
+export default PageEnter;

--- a/src/components/motion/TabEnter.tsx
+++ b/src/components/motion/TabEnter.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Box, BoxProps } from '@mui/material';
+import { ZPC_MOTION } from '../../theme/motion';
+
+type TabEnterProps = BoxProps & {
+  /** Active tab / panel id — changing this restarts the enter animation */
+  tabKey: string | number;
+};
+
+/** Fade + slight rise when switching tabs / sections. */
+const TabEnter: React.FC<TabEnterProps> = ({ tabKey, children, sx, ...rest }) => (
+  <Box
+    key={tabKey}
+    sx={{
+      width: '100%',
+      animation: `zpcTabIn ${ZPC_MOTION.tab}ms ${ZPC_MOTION.ease} both`,
+      '@media (prefers-reduced-motion: reduce)': {
+        animation: 'none',
+      },
+      ...sx,
+    }}
+    {...rest}
+  >
+    {children}
+  </Box>
+);
+
+export default TabEnter;

--- a/src/graphql/admin.ts
+++ b/src/graphql/admin.ts
@@ -14,7 +14,6 @@ export const ADMIN_USERS = gql`
       latitude
       longitude
       isactive
-      lastLoginAt
       emailVerified
       phoneVerified
       createdAt
@@ -24,27 +23,68 @@ export const ADMIN_USERS = gql`
   }
 `;
 
-/** Admin console — property inventory. */
+/** Admin console — published inventory. */
 export const ADMIN_PROPERTIES = gql`
-  query AdminProperties($query: String) {
-    searchProperties(query: $query) {
-      propertyId
-      userId
-      title
-      description
-      price
-      location
-      city
-      state
-      propertyType
-      status
-      isActive
-      bedrooms
-      bathrooms
-      area
-      viewCount
-      createdAt
-      updatedAt
+  query AdminProperties($page: Int, $limit: Int) {
+    publicProperties(page: $page, limit: $limit) {
+      total
+      page
+      limit
+      properties {
+        id
+        propertyCode
+        title
+        description
+        createdBy
+        creatorFirstName
+        creatorLastName
+        creatorEmail
+        price
+        currency
+        city
+        state
+        country
+        propertyType
+        listingType
+        status
+        verificationStatus
+        viewCount
+        createdAt
+        updatedAt
+      }
+    }
+  }
+`;
+
+/** Admin console — pending verification queue. */
+export const ADMIN_PENDING_PROPERTIES = gql`
+  query AdminPendingProperties($page: Int, $limit: Int) {
+    pendingProperties(page: $page, limit: $limit) {
+      total
+      page
+      limit
+      properties {
+        id
+        propertyCode
+        title
+        description
+        createdBy
+        creatorFirstName
+        creatorLastName
+        creatorEmail
+        price
+        currency
+        city
+        state
+        country
+        propertyType
+        listingType
+        status
+        verificationStatus
+        viewCount
+        createdAt
+        updatedAt
+      }
     }
   }
 `;
@@ -64,13 +104,50 @@ export const ADMIN_POSTS = gql`
       status
       likeCount
       commentCount
+      reportCount
       createdAt
     }
   }
 `;
 
+export const ADMIN_REPORTS = gql`
+  query AdminReports($status: String, $page: Int, $limit: Int) {
+    reports(status: $status, page: $page, limit: $limit) {
+      totalCount
+      page
+      totalPages
+      reports {
+        id
+        reportCode
+        entityType
+        entityId
+        reportedBy
+        reportedUserId
+        reasonCode
+        description
+        status
+        priority
+        createdAt
+      }
+    }
+  }
+`;
+
+export const ADMIN_REPORT_STATS = gql`
+  query AdminReportStats {
+    reportStats {
+      pendingCount
+      underReviewCount
+      resolvedCount
+      rejectedCount
+      highPriorityCount
+      totalCount
+    }
+  }
+`;
+
 export const ADMIN_DELETE_POST = gql`
-  mutation AdminDeletePost($postId: Int!) {
+  mutation AdminDeletePost($postId: String!) {
     deletePost(postId: $postId) {
       success
       message
@@ -80,18 +157,64 @@ export const ADMIN_DELETE_POST = gql`
 
 export const ADMIN_DELETE_PROPERTY = gql`
   mutation AdminDeleteProperty($propertyId: String!) {
-    deleteProperty(propertyId: $propertyId)
+    deleteProperty(propertyId: $propertyId) {
+      success
+      message
+    }
   }
 `;
 
 export const ADMIN_UPDATE_USER_ROLE = gql`
-  mutation AdminUpdateUserRole($userId: Int!, $role: String!) {
+  mutation AdminUpdateUserRole($userId: String!, $role: String!) {
     updateUserRole(userId: $userId, role: $role) {
       id
       role
       firstName
       lastName
       email
+    }
+  }
+`;
+
+export const ADMIN_APPROVE_PROPERTY = gql`
+  mutation AdminApproveProperty($propertyId: String!) {
+    approveProperty(propertyId: $propertyId) {
+      id
+      status
+      verificationStatus
+      title
+    }
+  }
+`;
+
+export const ADMIN_REJECT_PROPERTY = gql`
+  mutation AdminRejectProperty($propertyId: String!, $reason: String!) {
+    rejectProperty(propertyId: $propertyId, reason: $reason) {
+      id
+      status
+      verificationStatus
+      title
+    }
+  }
+`;
+
+export const ADMIN_UPDATE_REPORT_STATUS = gql`
+  mutation AdminUpdateReportStatus(
+    $reportId: String!
+    $status: String!
+    $reviewedBy: String
+    $actionTaken: String
+    $actionNote: String
+  ) {
+    updateReportStatus(
+      reportId: $reportId
+      status: $status
+      reviewedBy: $reviewedBy
+      actionTaken: $actionTaken
+      actionNote: $actionNote
+    ) {
+      success
+      message
     }
   }
 `;

--- a/src/graphql/posts.ts
+++ b/src/graphql/posts.ts
@@ -125,6 +125,37 @@ export const SEARCH_POSTS = gql`
   }
 `;
 
+/** Lightweight search cards — no media / geo to avoid S3 presign cost */
+export const SEARCH_POSTS_LIGHT = gql`
+  query SearchPostsLight(
+    $page: Int = 1
+    $limit: Int = 10
+    $query: String
+    $location: String
+    $propertyType: String
+  ) {
+    searchPosts(
+      page: $page
+      limit: $limit
+      query: $query
+      location: $location
+      propertyType: $propertyType
+    ) {
+      id
+      userId
+      userFirstName
+      userLastName
+      title
+      content
+      location
+      propertyType
+      createdAt
+      likeCount
+      commentCount
+    }
+  }
+`;
+
 export const TRENDING_POSTS = gql`
   query TrendingPosts($limit: Int = 5) {
     trendingPosts(limit: $limit) {
@@ -151,6 +182,7 @@ export const GET_POST_COMMENTS = gql`
       addedAt
       commentedAt
       editedAt
+      likeCount
       profilePhoto
       profilePhotoSignedUrl
       replies {
@@ -169,8 +201,58 @@ export const GET_POST_COMMENTS = gql`
         likeCount
         profilePhoto
         profilePhotoSignedUrl
+        replies {
+          id
+          postId
+          userId
+          userFirstName
+          userLastName
+          userRole
+          comment
+          parentCommentId
+          status
+          addedAt
+          commentedAt
+          editedAt
+          likeCount
+          profilePhoto
+          profilePhotoSignedUrl
+          replies {
+            id
+            postId
+            userId
+            userFirstName
+            userLastName
+            userRole
+            comment
+            parentCommentId
+            status
+            addedAt
+            commentedAt
+            editedAt
+            likeCount
+            profilePhoto
+            profilePhotoSignedUrl
+            replies {
+              id
+              postId
+              userId
+              userFirstName
+              userLastName
+              userRole
+              comment
+              parentCommentId
+              status
+              addedAt
+              commentedAt
+              editedAt
+              likeCount
+              profilePhoto
+              profilePhotoSignedUrl
+            }
+          }
+        }
       }
-      likeCount
     }
   }
 `;
@@ -461,6 +543,26 @@ export const REPORT_POST = gql`
         id
         reportCode
         status
+      }
+    }
+  }
+`;
+
+export const GET_POST_LIKES = gql`
+  query PostLikes($postId: String!, $page: Int, $limit: Int) {
+    postLikes(postId: $postId, page: $page, limit: $limit) {
+      totalCount
+      page
+      totalPages
+      likes {
+        userId
+        firstName
+        lastName
+        userRole
+        reactionType
+        likedAt
+        profilePhoto
+        profilePhotoSignedUrl
       }
     }
   }

--- a/src/graphql/property.ts
+++ b/src/graphql/property.ts
@@ -13,6 +13,7 @@ export const PROPERTY_FIELDS = gql`
     creatorRole
     builderName
     projectName
+    reraId
     propertyType
     listingType
     price

--- a/src/graphql/user.ts
+++ b/src/graphql/user.ts
@@ -15,8 +15,8 @@ export const GET_USERS = gql`
 `;
 
 export const SEARCH_USERS_LIGHT = gql`
-  query SearchUsersLight($search: String, $page: Int, $limit: Int) {
-    users(search: $search, page: $page, limit: $limit) {
+  query SearchUsersLight($search: String, $page: Int, $limit: Int, $role: String) {
+    users(search: $search, page: $page, limit: $limit, role: $role) {
       id
       firstName
       lastName

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,13 @@
+html,
 body {
   margin: 0;
+  min-height: 100%;
+  background-color: #B2DFDB;
+}
+
+body {
   font-family: 'Source Serif 4', 'Source Serif Pro', Georgia, serif;
   color: #0A1210;
-  background-color: #EBE6D4;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -68,4 +73,39 @@ code {
   font-size: 1.25rem;
   line-height: 1;
   filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.15));
+}
+
+/*
+ * Shared shell motion (pages, tabs, custom popups).
+ * Page enter must NOT use transform — a retained translateY(0) from
+ * animation-fill-mode:both creates a containing block and breaks
+ * position:fixed descendants (sticky header + viewport atmosphere).
+ */
+@keyframes zpcPageIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes zpcTabIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes zpcPopupIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
 }

--- a/src/services/propertyService.ts
+++ b/src/services/propertyService.ts
@@ -143,9 +143,15 @@ export const mapFormDataToPropertyInput = (formData: {
   country?: string;
   bedrooms?: string;
   bathrooms?: string;
+  builderName?: string;
+  projectName?: string;
+  reraId?: string;
 }): CreatePropertyInput => ({
   title: formData.title || '',
   description: formData.description || '',
+  builderName: formData.builderName || '',
+  projectName: formData.projectName || '',
+  reraId: formData.reraId || '',
   propertyType: formData.propertyType || 'APARTMENT',
   listingType: formData.listingType || 'SALE',
   price: parseFloat(formData.price) || 0,

--- a/src/theme/motion.ts
+++ b/src/theme/motion.ts
@@ -1,0 +1,33 @@
+/** Shared motion tokens — keep overlays / tabs / page enters feeling consistent. */
+
+export const ZPC_MOTION = {
+  ease: 'cubic-bezier(0.22, 1, 0.36, 1)',
+  easeOut: 'cubic-bezier(0.16, 1, 0.3, 1)',
+  /** Dialog / centered modal enter */
+  popupEnter: 280,
+  popupExit: 180,
+  /** Drawer / bottom sheet */
+  drawerEnter: 300,
+  drawerExit: 220,
+  /** Route / major page enter */
+  page: 340,
+  /** In-page tab / section switch */
+  tab: 260,
+  /** Menus, popovers, lightweight surfaces */
+  popover: 180,
+} as const;
+
+export const ZPC_TRANSITION = {
+  popup: {
+    enter: ZPC_MOTION.popupEnter,
+    exit: ZPC_MOTION.popupExit,
+  },
+  drawer: {
+    enter: ZPC_MOTION.drawerEnter,
+    exit: ZPC_MOTION.drawerExit,
+  },
+  popover: {
+    enter: ZPC_MOTION.popover,
+    exit: 140,
+  },
+} as const;

--- a/src/theme/surfaces.ts
+++ b/src/theme/surfaces.ts
@@ -2,6 +2,35 @@
 
 import { ZPC_COLORS, ZPC_GLASS } from './zpcTheme';
 
+/** Thin cream/forest scrollbar for modal bodies (Create Post / Property). */
+export const THIN_CREAM_SCROLLBAR = {
+  scrollbarWidth: 'thin' as const,
+  scrollbarColor: 'rgba(22,48,42,0.35) rgba(235,230,212,0.55)',
+  '&::-webkit-scrollbar': {
+    width: 8,
+    height: 8,
+  },
+  '&::-webkit-scrollbar-track': {
+    marginTop: 8,
+    marginBottom: 8,
+    background: 'rgba(235,230,212,0.45)',
+    borderRadius: 999,
+  },
+  '&::-webkit-scrollbar-thumb': {
+    background: 'rgba(22,48,42,0.32)',
+    borderRadius: 999,
+    border: '2px solid transparent',
+    backgroundClip: 'padding-box',
+    '&:hover': {
+      background: 'rgba(22,48,42,0.48)',
+      backgroundClip: 'padding-box',
+    },
+  },
+  '&::-webkit-scrollbar-corner': {
+    background: 'transparent',
+  },
+} as const;
+
 export const MATTE_SURFACE = {
   bgcolor: ZPC_GLASS.panel,
   backgroundColor: ZPC_GLASS.panel,
@@ -14,16 +43,17 @@ export const MATTE_SURFACE = {
     '0 1px 2px rgba(10, 18, 16, 0.06), 0 10px 28px rgba(10, 18, 16, 0.08), inset 0 1px 0 rgba(235,230,212,0.4)',
 } as const;
 
-/** App header — translucent forest green glass (same as Admin). */
+/** App header — translucent forest green glass (glossy, not solid fill). */
 export const MATTE_HEADER = {
-  bgcolor: 'rgba(22, 48, 42, 0.38) !important',
-  backgroundColor: 'rgba(22, 48, 42, 0.38) !important',
+  bgcolor: 'rgba(22, 48, 42, 0.32) !important',
+  backgroundColor: 'rgba(22, 48, 42, 0.32) !important',
   backgroundImage:
-    'linear-gradient(180deg, rgba(22,48,42,0.48) 0%, rgba(22,48,42,0.28) 100%)',
-  backdropFilter: 'blur(18px) saturate(1.25)',
-  WebkitBackdropFilter: 'blur(18px) saturate(1.25)',
+    'linear-gradient(180deg, rgba(22,48,42,0.42) 0%, rgba(22,48,42,0.22) 55%, rgba(22,48,42,0.28) 100%), linear-gradient(180deg, rgba(235,230,212,0.14) 0%, rgba(235,230,212,0) 42%)',
+  backdropFilter: 'blur(20px) saturate(1.35)',
+  WebkitBackdropFilter: 'blur(20px) saturate(1.35)',
   borderBottom: '1px solid rgba(235,230,212,0.28)',
-  boxShadow: '0 8px 28px rgba(10, 18, 16, 0.12), inset 0 1px 0 rgba(235,230,212,0.18)',
+  boxShadow:
+    '0 8px 28px rgba(10, 18, 16, 0.14), inset 0 1px 0 rgba(235,230,212,0.28), inset 0 -1px 0 rgba(10,18,16,0.12)',
   color: ZPC_COLORS.primaryContrast,
 } as const;
 
@@ -40,14 +70,14 @@ export const GLASS_GREEN = {
   boxShadow: '0 16px 40px rgba(0,0,0,0.22), inset 0 1px 0 rgba(235,230,212,0.2)',
 } as const;
 
-/** Page atmosphere — Admin sage green wash (Home / Profile / Admin). */
+/** Page atmosphere — soft mint wash (#B2DFDB) for Home / Profile / Search / Admin. */
 export const PAGE_ATMOSPHERE = {
-  bgcolor: '#CBD2C4',
-  backgroundColor: '#CBD2C4',
+  bgcolor: '#B2DFDB',
+  backgroundColor: '#B2DFDB',
   backgroundImage:
-    `radial-gradient(ellipse at 18% 12%, rgba(235,230,212,0.5) 0%, transparent 42%),
-     radial-gradient(ellipse at 82% 8%, rgba(95,134,112,0.45) 0%, transparent 45%),
-     linear-gradient(160deg, #5F8670 0%, #8FA998 42%, #CBD2C4 100%)`,
+    `radial-gradient(ellipse at 18% 12%, rgba(235,230,212,0.55) 0%, transparent 42%),
+     radial-gradient(ellipse at 82% 8%, rgba(0,121,107,0.22) 0%, transparent 46%),
+     linear-gradient(160deg, #80CBC4 0%, #B2DFDB 48%, #E0F2F1 100%)`,
   backgroundAttachment: 'fixed' as const,
   backgroundRepeat: 'no-repeat',
   backgroundSize: 'cover',

--- a/src/theme/zpcTheme.ts
+++ b/src/theme/zpcTheme.ts
@@ -34,7 +34,7 @@ export const ZPC_GLASS = {
   green: 'rgba(22, 48, 42, 0.16)',
   greenLogin: 'rgba(22, 48, 42, 0.22)',
   greenBorder: 'rgba(235, 230, 212, 0.35)',
-  header: 'rgba(22, 48, 42, 0.38)',
+  header: 'rgba(22, 48, 42, 0.32)',
   inset: 'rgba(22, 48, 42, 0.08)',
   tab: 'rgba(232, 226, 206, 0.4)',
   tabActive: 'rgba(22, 48, 42, 0.88)',

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -19,7 +19,10 @@ export enum ListingType {
 
 export enum PropertyStatus {
   DRAFT = 'DRAFT',
+  PENDING_VERIFICATION = 'PENDING_VERIFICATION',
+  UNDER_REVIEW = 'UNDER_REVIEW',
   PUBLISHED = 'PUBLISHED',
+  REJECTED = 'REJECTED',
   SOLD = 'SOLD',
   RENTED = 'RENTED',
   INACTIVE = 'INACTIVE',
@@ -45,6 +48,7 @@ export interface Property {
   creatorRole?: string;
   builderName?: string;
   projectName?: string;
+  reraId?: string;
   propertyType: string;
   listingType: string;
   price: number;
@@ -85,6 +89,7 @@ export interface CreatePropertyInput {
   description?: string;
   builderName?: string;
   projectName?: string;
+  reraId?: string;
   propertyType?: string;
   listingType?: string;
   price?: number;

--- a/src/utils/mentions.tsx
+++ b/src/utils/mentions.tsx
@@ -38,6 +38,115 @@ export function extractMentionedUserIds(content: string, extraIds: string[] = []
   return Array.from(ids);
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Expand pretty "@Name" mentions back to `@[id:Name]` / `@[p:id:Name]`
+ * using maps collected when the user picked suggestions.
+ */
+export function expandPrettyMentions(
+  content: string,
+  userNameToId: Map<string, string> | Record<string, string>,
+  propertyNameToId: Map<string, string> | Record<string, string> = {},
+): string {
+  let out = content || '';
+  const users =
+    userNameToId instanceof Map
+      ? Array.from(userNameToId.entries())
+      : Object.entries(userNameToId);
+  const props =
+    propertyNameToId instanceof Map
+      ? Array.from(propertyNameToId.entries())
+      : Object.entries(propertyNameToId);
+
+  const apply = (entries: [string, string][], asProperty: boolean) => {
+    entries
+      .filter(([name, id]) => name && id)
+      .sort((a, b) => b[0].length - a[0].length)
+      .forEach(([name, id]) => {
+        const safe = escapeRegExp(name);
+        const re = new RegExp(`@${safe}(?![\\w])`, 'g');
+        const token = asProperty ? `@[p:${id}:${name}]` : `@[${id}:${name}]`;
+        out = out.replace(re, token);
+      });
+  };
+
+  apply(users, false);
+  apply(props, true);
+  return out;
+}
+
+/** Approximate caret (x,y) inside a textarea relative to the textarea itself. */
+export function getTextareaCaretOffset(
+  element: HTMLTextAreaElement | HTMLInputElement,
+  position: number,
+): { top: number; left: number; height: number } {
+  if (!(element instanceof HTMLTextAreaElement)) {
+    return { top: element.offsetHeight, left: 12, height: 20 };
+  }
+
+  const div = document.createElement('div');
+  const style = window.getComputedStyle(element);
+  const props = [
+    'direction',
+    'boxSizing',
+    'width',
+    'height',
+    'overflowX',
+    'overflowY',
+    'borderTopWidth',
+    'borderRightWidth',
+    'borderBottomWidth',
+    'borderLeftWidth',
+    'paddingTop',
+    'paddingRight',
+    'paddingBottom',
+    'paddingLeft',
+    'fontStyle',
+    'fontVariant',
+    'fontWeight',
+    'fontStretch',
+    'fontSize',
+    'fontSizeAdjust',
+    'lineHeight',
+    'fontFamily',
+    'textAlign',
+    'textTransform',
+    'textIndent',
+    'textDecoration',
+    'letterSpacing',
+    'wordSpacing',
+    'tabSize',
+    'whiteSpace',
+    'wordBreak',
+    'wordWrap',
+  ] as const;
+
+  div.style.position = 'absolute';
+  div.style.visibility = 'hidden';
+  div.style.whiteSpace = 'pre-wrap';
+  div.style.wordWrap = 'break-word';
+  props.forEach((prop) => {
+    (div.style as any)[prop] = (style as any)[prop];
+  });
+  div.style.overflow = 'hidden';
+
+  div.textContent = element.value.slice(0, position);
+  const span = document.createElement('span');
+  span.textContent = element.value.slice(position) || '.';
+  div.appendChild(span);
+
+  document.body.appendChild(div);
+  const top = span.offsetTop - element.scrollTop;
+  const left = span.offsetLeft - element.scrollLeft;
+  const height = span.offsetHeight || parseInt(style.lineHeight, 10) || 20;
+  document.body.removeChild(div);
+
+  return { top, left, height };
+}
+
 export function renderMentionContent(
   content: string,
   opts: {

--- a/src/utils/nestComments.ts
+++ b/src/utils/nestComments.ts
@@ -1,37 +1,49 @@
 /**
- * Ensures replies sit under their parent for one-level display.
- * Handles both nested API payloads and flat lists with parentCommentId.
+ * Builds a nested comment tree from flat lists and/or server-nested replies.
+ * Preserves multi-level reply chains (reply → reply → …).
  */
 export function nestComments(comments: any[] | null | undefined): any[] {
   if (!comments?.length) return [];
 
   const nodes = new Map<string, any>();
-  comments.forEach((raw) => {
+
+  const ensureNode = (raw: any) => {
     const id = String(raw.id);
     const existing = nodes.get(id);
-    const fromServer = Array.isArray(raw.replies) ? raw.replies : [];
-    nodes.set(id, {
-      ...raw,
-      replies: existing?.replies?.length ? existing.replies : fromServer.slice(),
-    });
-  });
+    if (existing) {
+      nodes.set(id, {
+        ...existing,
+        ...raw,
+        replies: existing.replies?.length ? existing.replies : [],
+      });
+      return nodes.get(id)!;
+    }
+    const node = { ...raw, replies: [] as any[] };
+    nodes.set(id, node);
+    return node;
+  };
 
-  // Index nested reply ids already present on parents
-  const claimed = new Set<string>();
-  Array.from(nodes.values()).forEach((node) => {
-    const nested: any[] = [];
-    (node.replies || []).forEach((reply: any) => {
-      const rid = String(reply.id);
-      claimed.add(rid);
-      if (!nodes.has(rid)) {
-        nodes.set(rid, { ...reply, replies: [] });
+  const ingest = (raw: any) => {
+    const node = ensureNode(raw);
+    const nested = Array.isArray(raw.replies) ? raw.replies : [];
+    nested.forEach((reply: any) => {
+      const child = ingest(reply);
+      if (!(node.replies || []).some((r: any) => String(r.id) === String(child.id))) {
+        node.replies = (node.replies || []).concat([child]);
       }
-      nested.push(nodes.get(rid));
     });
-    node.replies = nested;
+    return node;
+  };
+
+  comments.forEach(ingest);
+
+  const claimed = new Set<string>();
+  const roots: any[] = [];
+
+  Array.from(nodes.values()).forEach((node) => {
+    (node.replies || []).forEach((reply: any) => claimed.add(String(reply.id)));
   });
 
-  const roots: any[] = [];
   comments.forEach((raw) => {
     const id = String(raw.id);
     if (claimed.has(id)) return;
@@ -48,22 +60,12 @@ export function nestComments(comments: any[] | null | undefined): any[] {
         parent.replies = (parent.replies || []).concat([node]);
       }
       claimed.add(id);
+    } else if (!parentId) {
+      roots.push(node);
     } else {
+      // Orphaned reply (parent missing from page) — still show as root-ish entry
       roots.push(node);
     }
-  });
-
-  // One-level threads: hoist any reply-of-reply onto the root comment
-  roots.forEach((root) => {
-    const flat: any[] = [];
-    const walk = (items: any[]) => {
-      (items || []).forEach((item) => {
-        flat.push({ ...item, replies: [] });
-        if (item.replies?.length) walk(item.replies);
-      });
-    };
-    walk(root.replies || []);
-    root.replies = flat;
   });
 
   return roots;

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -1,11 +1,29 @@
 import { UserInfo } from '../types/auth';
 
 export function normalizeRole(role?: string | null): string {
-  return (role || '').trim().toLowerCase();
+  const r = (role || '').trim().toLowerCase();
+  if (r === 'user' || r === 'general' || r === 'general_user') return 'general';
+  return r;
 }
 
 export function isAdminRole(role?: string | null): boolean {
   return normalizeRole(role) === 'admin';
+}
+
+/** Agent & Builder may list properties; Admin/General cannot create. */
+export function canCreateProperty(role?: string | null): boolean {
+  const r = normalizeRole(role);
+  return r === 'agent' || r === 'builder';
+}
+
+/** Alias for nav / “My Properties” entry points. */
+export function canManageProperties(role?: string | null): boolean {
+  return canCreateProperty(role);
+}
+
+/** Previously builders auto-published; all listings now await admin review. */
+export function canPublishPropertyImmediately(_role?: string | null): boolean {
+  return false;
 }
 
 /** Where to send the user after a successful login. */

--- a/src/utils/sharePost.ts
+++ b/src/utils/sharePost.ts
@@ -1,0 +1,57 @@
+export type ShareablePost = {
+  id: string | number;
+  title?: string | null;
+  content?: string | null;
+};
+
+export function buildPostShareUrl(postId: string | number): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  return `${origin}/home?post=${encodeURIComponent(String(postId))}`;
+}
+
+export function buildPostShareText(post: ShareablePost, url: string): string {
+  const title = (post.title || '').trim();
+  const content = (post.content || '')
+    .trim()
+    .replace(/\s+/g, ' ');
+  const preview = content.length > 160 ? `${content.slice(0, 157)}...` : content;
+  const head = title || 'Check out this post on ZPC';
+  return preview ? `${head}\n\n${preview}\n\n${url}` : `${head}\n\n${url}`;
+}
+
+export function whatsappShareUrl(text: string): string {
+  return `https://wa.me/?text=${encodeURIComponent(text)}`;
+}
+
+export function telegramShareUrl(url: string, text: string): string {
+  return `https://t.me/share/url?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;
+}
+
+export function gmailShareUrl(subject: string, body: string): string {
+  return `https://mail.google.com/mail/?view=cm&fs=1&tf=1&su=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}
+
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    /* fall through */
+  }
+  try {
+    const el = document.createElement('textarea');
+    el.value = text;
+    el.setAttribute('readonly', '');
+    el.style.position = 'fixed';
+    el.style.left = '-9999px';
+    document.body.appendChild(el);
+    el.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(el);
+    return ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Gate Create Property / My Properties to Agent & Builder; all new listings go Under Review
- Redesign create-property flow + property page (RERA shows — when empty; no fake property-code fallback)
- Messaging: start DM from search, remove Groups, fix dock open path; sticky header / atmosphere scroll fix
- Signup profession cards in one row; admin sidebar uses ZPC logo; Create Post/Property thin cream scrollbars
- Motion system, Share sheet, search/mention performance UX, Profile → Message dock wiring

## Test plan
- [ ] As Agent/Builder: create property → Under Review success modal; My Properties visible
- [ ] As Admin/General: no Create/My Properties nav; /create-property access denied
- [ ] Property page without RERA shows "—" (not PROP-*)
- [ ] Home Messaging: search person → chat pane opens left of inbox
- [ ] Scroll Home: header stays fixed, no double-shade background band
- [ ] Signup: Agent/Builder/General in one row